### PR TITLE
atualização de relatorios

### DIFF
--- a/ieducar/Modifiers/MinutesFinalResultModifier.php
+++ b/ieducar/Modifiers/MinutesFinalResultModifier.php
@@ -8,6 +8,7 @@ class MinutesFinalResultModifier extends BaseModifier
     private $statistics = [
         'students' => 0,
         'approved' => 0,
+        'approved_by_council' => 0,
         'disapproved' => 0,
         'studying' => 0,
         'transferred' => 0,
@@ -274,6 +275,9 @@ class MinutesFinalResultModifier extends BaseModifier
                 break;
             case App_Model_MatriculaSituacao::EM_ANDAMENTO:
                 $this->statistics['studying']++;
+                break;
+            case App_Model_MatriculaSituacao::APROVADO_PELO_CONSELHO:
+                $this->statistics['approved_by_council']++;
                 break;
             case App_Model_MatriculaSituacao::TRANSFERIDO:
                 $this->statistics['transferred']++;

--- a/ieducar/Queries/QueryMinutesFinalResult.php
+++ b/ieducar/Queries/QueryMinutesFinalResult.php
@@ -100,6 +100,8 @@ class QueryMinutesFinalResult extends QueryBridge
                    AND turma.cod_turma = $P{turma}
                    AND view_situacao.cod_situacao = $P{situacao}
                    AND CASE WHEN $P!{filtro_areas_conhecimento} THEN true ELSE cc.area_conhecimento_id IN ($P!{areas_conhecimento}) END
+                   AND view_componente_curricular.nome !~ '([a-zA-Z]{2}[0-9]{2}){2}'
+                   AND view_componente_curricular.nome !~ '[0-9][0-9]?.'
                 ORDER BY nm_escola,
                           curso.nm_curso,
                           serie.nm_serie,

--- a/ieducar/Queries/QueryMinutesFinalResult.php
+++ b/ieducar/Queries/QueryMinutesFinalResult.php
@@ -100,6 +100,25 @@ class QueryMinutesFinalResult extends QueryBridge
                    AND turma.cod_turma = $P{turma}
                    AND view_situacao.cod_situacao = $P{situacao}
                    AND CASE WHEN $P!{filtro_areas_conhecimento} THEN true ELSE cc.area_conhecimento_id IN ($P!{areas_conhecimento}) END
+                   AND matricula_turma.sequencial = (SELECT max(mt.sequencial)
+                                                     FROM pmieducar.matricula_turma mt
+                                                     WHERE mt.ref_cod_matricula = matricula.cod_matricula
+                                                       AND mt.ref_cod_turma = turma.cod_turma
+                                                       AND (mt.ativo = 1 OR (
+                                                         mt.transferido OR
+                                                         mt.remanejado OR
+                                                         mt.reclassificado OR
+                                                         mt.abandono OR
+                                                         mt.falecido
+                                                       )))
+                   AND NOT EXISTS (SELECT *
+                                    FROM pmieducar.matricula_turma mt
+                                   INNER JOIN pmieducar.matricula m ON (m.cod_matricula = mt.ref_cod_matricula)
+                                   WHERE mt.ref_cod_turma = matricula_turma.ref_cod_turma
+                                     AND mt.ref_cod_matricula <> matricula_turma.ref_cod_matricula
+                                     AND m.ref_cod_aluno = matricula.ref_cod_aluno
+                                     AND mt.data_enturmacao > matricula_turma.data_enturmacao
+                                     AND m.ativo = 1)
                    AND view_componente_curricular.nome !~ '([a-zA-Z]{2}[0-9]{2}){2}'
                    AND view_componente_curricular.nome !~ '[0-9][0-9]?.'
                 ORDER BY nm_escola,

--- a/ieducar/ReportSources/final-result-conceptual.jrxml
+++ b/ieducar/ReportSources/final-result-conceptual.jrxml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.4.3  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="portabilis_resultado_final" language="groovy" pageWidth="842" pageHeight="595" orientation="Landscape" columnWidth="802" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" isSummaryWithPageHeaderAndFooter="true" uuid="0378c531-ef85-4c42-9c57-3c8660b99c2d">
     <property name="ireport.zoom" value="3.138428376721004"/>
     <property name="ireport.x" value="0"/>
     <property name="ireport.y" value="530"/>
-    <style name="Crosstab Data Text" hAlign="Center"/>
+    <style name="Crosstab Data Text" hTextAlign="Center" hImageAlign="Center"/>
     <style name="table">
         <box>
             <pen lineWidth="1.0" lineColor="#000000"/>
@@ -24,7 +25,7 @@
             <pen lineWidth="0.5" lineColor="#000000"/>
         </box>
     </style>
-    <style name="linha-zebrado" hAlign="Center">
+    <style name="linha-zebrado" hTextAlign="Center" hImageAlign="Center">
         <conditionalStyle>
             <conditionExpression><![CDATA[new Boolean(($V{ROW_COUNT}.intValue() % 2) == 0)]]></conditionExpression>
             <style backcolor="#F0F0F0"/>
@@ -98,7 +99,7 @@
                 <elementGroup>
                     <elementGroup>
                         <crosstab>
-                            <reportElement uuid="4c50a099-4f7c-4636-951b-21df04d0e54a" x="21" y="2" width="766" height="46"/>
+                            <reportElement x="21" y="2" width="766" height="46" uuid="4c50a099-4f7c-4636-951b-21df04d0e54a"/>
                             <crosstabDataset isDataPreSorted="true"/>
                             <crosstabHeaderCell>
                                 <cellContents mode="Opaque">
@@ -110,21 +111,21 @@
                                         <rightPen lineWidth="0.0"/>
                                     </box>
                                     <staticText>
-                                        <reportElement uuid="4aa69f0a-3518-4fa1-81ed-bebb10e531d9" style="Crosstab Data Text" x="20" y="5" width="259" height="15"/>
+                                        <reportElement style="Crosstab Data Text" x="20" y="5" width="259" height="15" uuid="4aa69f0a-3518-4fa1-81ed-bebb10e531d9"/>
                                         <textElement textAlignment="Left">
                                             <font fontName="DejaVu Sans" size="8" isBold="true"/>
                                         </textElement>
                                         <text><![CDATA[Aluno]]></text>
                                     </staticText>
                                     <staticText>
-                                        <reportElement uuid="2ba58a37-c9da-48d4-a2ac-086dc9849def" style="Crosstab Data Text" x="279" y="5" width="32" height="15"/>
+                                        <reportElement style="Crosstab Data Text" x="279" y="5" width="32" height="15" uuid="2ba58a37-c9da-48d4-a2ac-086dc9849def"/>
                                         <textElement textAlignment="Center">
                                             <font fontName="DejaVu Sans" size="8" isBold="true"/>
                                         </textElement>
                                         <text><![CDATA[Sit]]></text>
                                     </staticText>
                                     <staticText>
-                                        <reportElement uuid="93d25ded-82b7-42bd-800b-5c782568bed0" style="Crosstab Data Text" x="311" y="5" width="32" height="15"/>
+                                        <reportElement style="Crosstab Data Text" x="311" y="5" width="32" height="15" uuid="93d25ded-82b7-42bd-800b-5c782568bed0"/>
                                         <textElement textAlignment="Center">
                                             <font fontName="DejaVu Sans" size="8" isBold="true"/>
                                         </textElement>
@@ -146,7 +147,7 @@
                                             <rightPen lineWidth="0.0"/>
                                         </box>
                                         <textField isStretchWithOverflow="true">
-                                            <reportElement uuid="26451b38-4f94-4f1a-879d-a39854e52a6d" stretchType="RelativeToBandHeight" mode="Transparent" x="20" y="0" width="259" height="15"/>
+                                            <reportElement stretchType="ContainerHeight" mode="Transparent" x="20" y="0" width="259" height="15" uuid="26451b38-4f94-4f1a-879d-a39854e52a6d"/>
                                             <textElement textAlignment="Left" verticalAlignment="Middle" markup="html">
                                                 <font fontName="DejaVu Sans" size="8"/>
                                             </textElement>
@@ -173,7 +174,7 @@
                                 <crosstabRowHeader>
                                     <cellContents mode="Opaque" style="linha-zebrado">
                                         <textField isBlankWhenNull="true">
-                                            <reportElement uuid="815ac81e-a1c4-4ac0-ba55-bc9aabebb01b" stretchType="RelativeToBandHeight" mode="Transparent" x="0" y="0" width="32" height="15"/>
+                                            <reportElement stretchType="ContainerHeight" mode="Transparent" x="0" y="0" width="32" height="15" uuid="815ac81e-a1c4-4ac0-ba55-bc9aabebb01b"/>
                                             <textElement textAlignment="Center" verticalAlignment="Middle">
                                                 <font fontName="DejaVu Sans" size="8"/>
                                             </textElement>
@@ -192,7 +193,7 @@
                                 <crosstabRowHeader>
                                     <cellContents mode="Opaque" style="linha-zebrado">
                                         <textField isBlankWhenNull="true">
-                                            <reportElement uuid="051cef1f-d97b-49b5-8f0b-b5755efda5bb" stretchType="RelativeToBandHeight" mode="Transparent" x="0" y="0" width="32" height="15"/>
+                                            <reportElement stretchType="ContainerHeight" mode="Transparent" x="0" y="0" width="32" height="15" uuid="051cef1f-d97b-49b5-8f0b-b5755efda5bb"/>
                                             <textElement textAlignment="Center" verticalAlignment="Middle">
                                                 <font fontName="DejaVu Sans" size="8"/>
                                             </textElement>
@@ -218,7 +219,7 @@
                                             <rightPen lineWidth="0.0"/>
                                         </box>
                                         <textField>
-                                            <reportElement uuid="0d33f862-3339-44cc-9676-9ea84b5ee545" style="Crosstab Data Text" x="1" y="5" width="45" height="15"/>
+                                            <reportElement style="Crosstab Data Text" x="1" y="5" width="45" height="15" uuid="0d33f862-3339-44cc-9676-9ea84b5ee545"/>
                                             <textElement textAlignment="Center">
                                                 <font fontName="DejaVu Sans" size="8" isBold="true"/>
                                             </textElement>
@@ -241,6 +242,9 @@
                             <measure name="mediaMeasure" class="java.lang.String" calculation="First">
                                 <measureExpression><![CDATA[$F{media}]]></measureExpression>
                             </measure>
+                            <measure name="ano" class="java.lang.Integer" calculation="First">
+                                <measureExpression><![CDATA[$P{ano}]]></measureExpression>
+                            </measure>
                             <crosstabCell width="50" height="15">
                                 <cellContents mode="Opaque" style="linha-zebrado">
                                     <box>
@@ -251,11 +255,22 @@
                                         <rightPen lineWidth="0.0"/>
                                     </box>
                                     <textField isStretchWithOverflow="true" pattern="###0.00" isBlankWhenNull="false">
-                                        <reportElement uuid="5460d827-cdaa-4ea5-ab26-46e942baa06e" stretchType="RelativeToBandHeight" mode="Transparent" x="1" y="0" width="45" height="15" forecolor="#010101"/>
+                                        <reportElement stretchType="ContainerHeight" mode="Transparent" x="1" y="0" width="45" height="15" forecolor="#010101" uuid="5460d827-cdaa-4ea5-ab26-46e942baa06e">
+                                            <printWhenExpression><![CDATA[$V{ano} >= 2025]]></printWhenExpression>
+                                        </reportElement>
                                         <textElement textAlignment="Center" verticalAlignment="Middle">
                                             <font fontName="DejaVu Sans" size="8"/>
                                         </textElement>
                                         <textFieldExpression><![CDATA[$V{mediaMeasure} == null ? '-' : $V{mediaMeasure}]]></textFieldExpression>
+                                    </textField>
+                                    <textField isStretchWithOverflow="true" pattern="###0.00" isBlankWhenNull="false">
+                                        <reportElement stretchType="ContainerHeight" mode="Transparent" x="1" y="0" width="45" height="15" forecolor="#010101" uuid="aaadc1dd-5bd3-46b8-b2bd-e0c1353a6c2e">
+                                            <printWhenExpression><![CDATA[$V{ano} < 2025]]></printWhenExpression>
+                                        </reportElement>
+                                        <textElement textAlignment="Center" verticalAlignment="Middle">
+                                            <font fontName="DejaVu Sans" size="8"/>
+                                        </textElement>
+                                        <textFieldExpression><![CDATA[$V{mediaMeasure} == null ? '-' : ($V{mediaMeasure}.equalsIgnoreCase("EC") ? "I" : $V{mediaMeasure})]]></textFieldExpression>
                                     </textField>
                                 </cellContents>
                             </crosstabCell>
@@ -300,7 +315,7 @@
     <pageHeader>
         <band height="111">
             <subreport>
-                <reportElement uuid="b241df72-8ed9-4919-81e7-4e966a7b0ab4" x="0" y="0" width="802" height="110">
+                <reportElement x="0" y="0" width="802" height="110" uuid="b241df72-8ed9-4919-81e7-4e966a7b0ab4">
                     <printWhenExpression><![CDATA[$P{cabecalho_alternativo} != 1]]></printWhenExpression>
                 </reportElement>
                 <subreportParameter name="logo">
@@ -331,70 +346,70 @@
     <columnHeader>
         <band height="27">
             <staticText>
-                <reportElement uuid="a2fef46a-95ee-471f-954d-4c59ee3f6453" x="29" y="13" width="36" height="12"/>
+                <reportElement x="29" y="13" width="36" height="12" uuid="a2fef46a-95ee-471f-954d-4c59ee3f6453"/>
                 <textElement>
                     <font fontName="DejaVu Sans" size="8" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Curso:]]></text>
             </staticText>
             <staticText>
-                <reportElement uuid="3d7e5690-83cf-4b94-b4d6-3d02c54443b7" x="264" y="13" width="36" height="12"/>
+                <reportElement x="264" y="13" width="36" height="12" uuid="3d7e5690-83cf-4b94-b4d6-3d02c54443b7"/>
                 <textElement>
                     <font fontName="DejaVu Sans" size="8" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Turno:]]></text>
             </staticText>
             <staticText>
-                <reportElement uuid="aabaa5dd-00d4-4b0b-a6c9-89f34a9d414e" x="406" y="13" width="36" height="12"/>
+                <reportElement x="406" y="13" width="36" height="12" uuid="aabaa5dd-00d4-4b0b-a6c9-89f34a9d414e"/>
                 <textElement>
                     <font fontName="DejaVu Sans" size="8" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Turma:]]></text>
             </staticText>
             <staticText>
-                <reportElement uuid="7ee2cd94-a04f-4ff5-b054-cd07275a5ff9" x="542" y="13" width="51" height="12"/>
+                <reportElement x="542" y="13" width="51" height="12" uuid="7ee2cd94-a04f-4ff5-b054-cd07275a5ff9"/>
                 <textElement>
                     <font fontName="DejaVu Sans" size="8" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Série/Ano:]]></text>
             </staticText>
             <textField isBlankWhenNull="true">
-                <reportElement uuid="9863bd3d-2642-45a7-96fe-2246aad1c4a2" x="65" y="13" width="190" height="12"/>
+                <reportElement x="65" y="13" width="190" height="12" uuid="9863bd3d-2642-45a7-96fe-2246aad1c4a2"/>
                 <textElement>
                     <font fontName="DejaVu Sans" size="8"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$F{nome_curso}]]></textFieldExpression>
             </textField>
             <textField isBlankWhenNull="true">
-                <reportElement uuid="86af51bf-68d8-4122-abd6-9223d889777a" x="300" y="13" width="100" height="12"/>
+                <reportElement x="300" y="13" width="100" height="12" uuid="86af51bf-68d8-4122-abd6-9223d889777a"/>
                 <textElement>
                     <font fontName="DejaVu Sans" size="8"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$F{periodo}]]></textFieldExpression>
             </textField>
             <textField isBlankWhenNull="true">
-                <reportElement uuid="142a6ec1-4e1c-47b3-974d-bd2b7c097dd8" x="442" y="13" width="100" height="12"/>
+                <reportElement x="442" y="13" width="100" height="12" uuid="142a6ec1-4e1c-47b3-974d-bd2b7c097dd8"/>
                 <textElement>
                     <font fontName="DejaVu Sans" size="8"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$F{nome_turma}]]></textFieldExpression>
             </textField>
             <textField isBlankWhenNull="true">
-                <reportElement uuid="375f41e1-626b-44a6-a411-95e965ccc893" x="598" y="13" width="100" height="12"/>
+                <reportElement x="598" y="13" width="100" height="12" uuid="375f41e1-626b-44a6-a411-95e965ccc893"/>
                 <textElement>
                     <font fontName="DejaVu Sans" size="8"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$F{nome_serie}]]></textFieldExpression>
             </textField>
             <staticText>
-                <reportElement uuid="4e5bf517-6347-41ef-947e-a2800b0fc3d2" x="704" y="13" width="29" height="12"/>
+                <reportElement x="704" y="13" width="29" height="12" uuid="4e5bf517-6347-41ef-947e-a2800b0fc3d2"/>
                 <textElement>
                     <font fontName="DejaVu Sans" size="8" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Ano:]]></text>
             </staticText>
             <textField>
-                <reportElement uuid="4a53dec4-f655-4caa-881a-4cb00ffb31e3" x="733" y="13" width="45" height="12"/>
+                <reportElement x="733" y="13" width="45" height="12" uuid="4a53dec4-f655-4caa-881a-4cb00ffb31e3"/>
                 <textElement>
                     <font fontName="DejaVu Sans" size="8"/>
                 </textElement>
@@ -408,59 +423,59 @@
     <lastPageFooter>
         <band height="110">
             <line>
-                <reportElement uuid="9c6424ea-23ab-4cd8-b982-9f0b54a4f3e1" positionType="Float" x="217" y="12" width="160" height="1"/>
+                <reportElement positionType="Float" x="217" y="12" width="160" height="1" uuid="9c6424ea-23ab-4cd8-b982-9f0b54a4f3e1"/>
                 <graphicElement>
                     <pen lineWidth="0.25"/>
                 </graphicElement>
             </line>
             <line>
-                <reportElement uuid="bffb28dd-bc86-44a5-8e15-c36b63c67d3c" positionType="Float" x="29" y="12" width="160" height="1"/>
+                <reportElement positionType="Float" x="29" y="12" width="160" height="1" uuid="bffb28dd-bc86-44a5-8e15-c36b63c67d3c"/>
                 <graphicElement>
                     <pen lineWidth="0.25"/>
                 </graphicElement>
             </line>
             <line>
-                <reportElement uuid="8010fcda-e85d-4836-bd01-50253873299e" positionType="Float" x="600" y="12" width="160" height="1"/>
+                <reportElement positionType="Float" x="600" y="12" width="160" height="1" uuid="8010fcda-e85d-4836-bd01-50253873299e"/>
                 <graphicElement>
                     <pen lineWidth="0.25"/>
                 </graphicElement>
             </line>
             <textField>
-                <reportElement uuid="913914ab-9e81-48ac-aad9-36fa555325cd" positionType="Float" x="29" y="14" width="160" height="13"/>
+                <reportElement positionType="Float" x="29" y="14" width="160" height="13" uuid="913914ab-9e81-48ac-aad9-36fa555325cd"/>
                 <textElement textAlignment="Center" verticalAlignment="Top" markup="none">
                     <font fontName="DejaVu Sans" size="8" isBold="true"/>
                 </textElement>
                 <textFieldExpression><![CDATA["Aux. de " + $P{assinatura_secretario}]]></textFieldExpression>
             </textField>
             <textField>
-                <reportElement uuid="5d27eaba-528a-4e4d-bee9-e2211bf1617c" positionType="Float" x="217" y="14" width="160" height="13"/>
+                <reportElement positionType="Float" x="217" y="14" width="160" height="13" uuid="5d27eaba-528a-4e4d-bee9-e2211bf1617c"/>
                 <textElement textAlignment="Center" verticalAlignment="Top" markup="none">
                     <font fontName="DejaVu Sans" size="8" isBold="true"/>
                 </textElement>
                 <textFieldExpression><![CDATA[$P{assinatura_secretario}]]></textFieldExpression>
             </textField>
             <staticText>
-                <reportElement uuid="f5174235-bd1b-43e6-bfd1-8602fc3d8ff0" positionType="Float" x="600" y="14" width="160" height="13"/>
+                <reportElement positionType="Float" x="600" y="14" width="160" height="13" uuid="f5174235-bd1b-43e6-bfd1-8602fc3d8ff0"/>
                 <textElement textAlignment="Center" verticalAlignment="Top">
                     <font fontName="DejaVu Sans" size="8" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Diretor(a)]]></text>
             </staticText>
             <staticText>
-                <reportElement uuid="f5174235-bd1b-43e6-bfd1-8602fc3d8ff0" positionType="Float" x="409" y="14" width="160" height="13"/>
+                <reportElement positionType="Float" x="409" y="14" width="160" height="13" uuid="f5174235-bd1b-43e6-bfd1-8602fc3d8ff0"/>
                 <textElement textAlignment="Center" verticalAlignment="Top">
                     <font fontName="DejaVu Sans" size="8" isBold="true"/>
                 </textElement>
                 <text><![CDATA[Professor(a) regente]]></text>
             </staticText>
             <line>
-                <reportElement uuid="9c6424ea-23ab-4cd8-b982-9f0b54a4f3e1" positionType="Float" x="409" y="12" width="160" height="1"/>
+                <reportElement positionType="Float" x="409" y="12" width="160" height="1" uuid="9c6424ea-23ab-4cd8-b982-9f0b54a4f3e1"/>
                 <graphicElement>
                     <pen lineWidth="0.25"/>
                 </graphicElement>
             </line>
             <textField>
-                <reportElement uuid="443e16b3-c081-433c-bc23-4240d4f66eb6" x="0" y="91" width="802" height="19">
+                <reportElement x="0" y="91" width="802" height="19" uuid="443e16b3-c081-433c-bc23-4240d4f66eb6">
                     <printWhenExpression><![CDATA[$P{observacoes}.trim() != ""]]></printWhenExpression>
                 </reportElement>
                 <textElement textAlignment="Justified" verticalAlignment="Middle">
@@ -469,7 +484,7 @@
                 <textFieldExpression><![CDATA["* "+$P{observacoes}]]></textFieldExpression>
             </textField>
             <line>
-                <reportElement uuid="244ce0fd-ba8d-4782-b9b7-b921352fadea" x="0" y="91" width="802" height="1">
+                <reportElement x="0" y="91" width="802" height="1" uuid="244ce0fd-ba8d-4782-b9b7-b921352fadea">
                     <printWhenExpression><![CDATA[$P{observacoes}.trim() != ""]]></printWhenExpression>
                 </reportElement>
             </line>

--- a/ieducar/ReportSources/minutes-final-result-with-concept.jrxml
+++ b/ieducar/ReportSources/minutes-final-result-with-concept.jrxml
@@ -467,7 +467,7 @@
 						</crosstabTotalColumnHeader>
 					</columnGroup>
 					<measure name="notaMeasure" class="java.lang.String">
-						<measureExpression><![CDATA[$F{nota} == null ? " - " : $F{nota}]]></measureExpression>
+						<measureExpression><![CDATA[$F{carga_horaria_componente} == null ? "-" : $F{nota}]]></measureExpression>
 					</measure>
 					<measure name="count_aluno" class="java.lang.Integer">
 						<measureExpression><![CDATA[$F{aluno}]]></measureExpression>
@@ -690,6 +690,7 @@
 									<textElement textAlignment="Center" verticalAlignment="Middle">
 										<font fontName="DejaVu Sans" size="8"/>
 									</textElement>
+									<textFieldExpression><![CDATA[""]]></textFieldExpression>
 								</textField>
 								<textField isBlankWhenNull="true">
 									<reportElement style="linha-zebrado" mode="Opaque" x="323" y="10" width="42" height="11" uuid="53d680c6-c629-4588-a7df-5c16427abbe7"/>
@@ -766,19 +767,7 @@
 						</crosstabTotalColumnHeader>
 					</columnGroup>
 					<measure name="notaMeasure" class="java.lang.String">
-						<measureExpression><![CDATA[
-								$F{nota} == null || $F{nota}.trim().isEmpty()
-								? " - "
-								: (
-									$F{nota}.matches("[-+]?[0-9]*\\.?[0-9]+")
-									? String.format(
-										java.util.Locale.US,
-										"%.1f",
-										Double.valueOf($F{nota})
-									)
-									: $F{nota}
-								)
-							]]></measureExpression>
+						<measureExpression><![CDATA[$F{carga_horaria_componente} == null ? "-" : $F{nota}]]></measureExpression>
 					</measure>
 					<measure name="count_aluno" class="java.lang.Integer">
 						<measureExpression><![CDATA[$F{aluno}]]></measureExpression>

--- a/ieducar/ReportSources/minutes-final-result-with-concept.jrxml
+++ b/ieducar/ReportSources/minutes-final-result-with-concept.jrxml
@@ -795,7 +795,7 @@
 					</measure>
 					<crosstabCell width="30" height="22">
 						<cellContents>
-							<textField>
+							<textField isBlankWhenNull="true">
 								<reportElement style="linha-zebrado" mode="Opaque" x="0" y="0" width="30" height="11" uuid="9d614647-7929-4b26-94c1-f96f54422b39"/>
 								<box>
 									<topPen lineWidth="0.25"/>

--- a/ieducar/ReportSources/minutes-final-result-with-fixed-concept.jrxml
+++ b/ieducar/ReportSources/minutes-final-result-with-fixed-concept.jrxml
@@ -464,7 +464,7 @@
 						</crosstabTotalColumnHeader>
 					</columnGroup>
 					<measure name="notaMeasure" class="java.lang.String">
-						<measureExpression><![CDATA[$F{nota} == null ? " - " : $F{nota}]]></measureExpression>
+						<measureExpression><![CDATA[$F{carga_horaria_componente} == null ? "-" : $P{conceito_fixo}]]></measureExpression>
 					</measure>
 					<measure name="count_aluno" class="java.lang.Integer">
 						<measureExpression><![CDATA[$F{aluno}]]></measureExpression>
@@ -687,6 +687,7 @@
 									<textElement textAlignment="Center" verticalAlignment="Middle">
 										<font fontName="DejaVu Sans" size="8"/>
 									</textElement>
+									<textFieldExpression><![CDATA[""]]></textFieldExpression>
 								</textField>
 								<textField isBlankWhenNull="true">
 									<reportElement style="linha-zebrado" mode="Opaque" x="323" y="10" width="42" height="11" uuid="53d680c6-c629-4588-a7df-5c16427abbe7"/>
@@ -763,19 +764,7 @@
 						</crosstabTotalColumnHeader>
 					</columnGroup>
 					<measure name="notaMeasure" class="java.lang.String">
-						<measureExpression><![CDATA[
-								$F{nota} == null || $F{nota}.trim().isEmpty()
-								? " - "
-								: (
-									$F{nota}.matches("[-+]?[0-9]*\\.?[0-9]+")
-									? String.format(
-										java.util.Locale.US,
-										"%.1f",
-										Double.valueOf($F{nota})
-									)
-									: $F{nota}
-								)
-							]]></measureExpression>
+						<measureExpression><![CDATA[$F{carga_horaria_componente} == null ? "-" : $P{conceito_fixo}]]></measureExpression>
 					</measure>
 					<measure name="count_aluno" class="java.lang.Integer">
 						<measureExpression><![CDATA[$F{aluno}]]></measureExpression>

--- a/ieducar/ReportSources/minutes-final-result-with-fixed-concept.jrxml
+++ b/ieducar/ReportSources/minutes-final-result-with-fixed-concept.jrxml
@@ -87,7 +87,10 @@
 	<parameter name="source" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
-	<parameter name="observacao" class="java.lang.String"/>
+	<parameter name="observacao_b64" class="java.lang.String"/>
+	<parameter name="observacao" class="java.lang.String">
+		<defaultValueExpression><![CDATA[new String(java.util.Base64.getDecoder().decode($P{observacao_b64}), "UTF-8")]]></defaultValueExpression>
+	</parameter>
 	<parameter name="filtro_areas_conhecimento" class="java.lang.Boolean"/>
 	<parameter name="tem_conceito_fixo" class="java.lang.Boolean">
 		<defaultValueExpression><![CDATA[false]]></defaultValueExpression>

--- a/ieducar/ReportSources/minutes-final-result.jrxml
+++ b/ieducar/ReportSources/minutes-final-result.jrxml
@@ -66,6 +66,9 @@
 	<parameter name="data_emissao" class="java.lang.String">
 		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
 	</parameter>
+	<parameter name="data_encerramento" class="java.lang.String">
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
 	<parameter name="turma" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[0]]></defaultValueExpression>
 	</parameter>
@@ -939,7 +942,7 @@
 				<textElement textAlignment="Center">
 					<font fontName="DejaVu Sans" size="8"/>
 				</textElement>
-				<textFieldExpression><![CDATA[$F{cidade_instituicao} +", " +$F{data_extenso} + "."]]></textFieldExpression>
+				<textFieldExpression><![CDATA[$F{cidade_instituicao} +", " + ($P{data_encerramento} == null || $P{data_encerramento}.isEmpty() ? $F{data_extenso} : $P{data_encerramento})]]></textFieldExpression>
 			</textField>
 			<subreport>
 				<reportElement x="489" y="0" width="289" height="52" uuid="f46efc07-72eb-4d06-ad8e-b3928061285d"/>

--- a/ieducar/ReportSources/minutes-final-result.jrxml
+++ b/ieducar/ReportSources/minutes-final-result.jrxml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.4.3  -->
 <jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="portabilis_ata_resultado_final" language="groovy" pageWidth="823" pageHeight="612" orientation="Landscape" columnWidth="783" leftMargin="20" rightMargin="20" topMargin="20" bottomMargin="20" uuid="6aa6f40c-104d-4995-8361-09cc67a938a0">
 	<property name="ireport.zoom" value="1.1000000000000068"/>
 	<property name="ireport.x" value="0"/>
@@ -6,7 +7,7 @@
 	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w1" value="0"/>
 	<property name="com.jaspersoft.studio.data.sql.SQLQueryDesigner.sash.w2" value="1000"/>
 	<style name="Crosstab Data Text"/>
-	<style name="linha-zebrado" hAlign="Center">
+	<style name="linha-zebrado" hTextAlign="Center" hImageAlign="Center">
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($V{ROW_COUNT}.intValue() % 2) == 0)]]></conditionExpression>
 			<style backcolor="#F0F0F0"/>
@@ -32,7 +33,7 @@
 			<pen lineWidth="0.5" lineColor="#000000"/>
 		</box>
 	</style>
-	<style name="linha-zebrado_1" hAlign="Center">
+	<style name="linha-zebrado_1" hTextAlign="Center" hImageAlign="Center">
 		<conditionalStyle>
 			<conditionExpression><![CDATA[new Boolean(($V{REPORT_COUNT}.intValue() % 2) == 0)]]></conditionExpression>
 			<style backcolor="#F0F0F0"/>
@@ -124,65 +125,65 @@
 		<groupHeader>
 			<band height="35" splitType="Stretch">
 				<rectangle radius="0">
-					<reportElement uuid="c47f071a-d411-4f7d-aed9-c51f4b788537" stretchType="RelativeToBandHeight" x="0" y="13" width="778" height="22"/>
+					<reportElement stretchType="ContainerHeight" x="0" y="13" width="778" height="22" uuid="c47f071a-d411-4f7d-aed9-c51f4b788537"/>
 					<graphicElement>
 						<pen lineWidth="0.25"/>
 					</graphicElement>
 				</rectangle>
 				<staticText>
-					<reportElement uuid="2e8df1f3-663e-4235-9e1e-6dfa9982b505" x="10" y="14" width="91" height="10"/>
+					<reportElement x="10" y="14" width="91" height="10" uuid="2e8df1f3-663e-4235-9e1e-6dfa9982b505"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[Tipo de ensino]]></text>
 				</staticText>
 				<line>
-					<reportElement uuid="f2a5527b-8cd4-43db-8533-09be16611c78" stretchType="RelativeToTallestObject" x="169" y="13" width="1" height="22"/>
+					<reportElement stretchType="ElementGroupHeight" x="169" y="13" width="1" height="22" uuid="f2a5527b-8cd4-43db-8533-09be16611c78"/>
 					<graphicElement>
 						<pen lineWidth="0.25"/>
 					</graphicElement>
 				</line>
 				<line>
-					<reportElement uuid="f2a5527b-8cd4-43db-8533-09be16611c78" stretchType="RelativeToTallestObject" x="339" y="13" width="1" height="22"/>
+					<reportElement stretchType="ElementGroupHeight" x="339" y="13" width="1" height="22" uuid="f2a5527b-8cd4-43db-8533-09be16611c78"/>
 					<graphicElement>
 						<pen lineWidth="0.25"/>
 					</graphicElement>
 				</line>
 				<staticText>
-					<reportElement uuid="be83e4ba-bf3d-4b01-a633-23acc61b6f63" x="175" y="14" width="60" height="12"/>
+					<reportElement x="175" y="14" width="60" height="12" uuid="be83e4ba-bf3d-4b01-a633-23acc61b6f63"/>
 					<textElement markup="none">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[Série]]></text>
 				</staticText>
 				<line>
-					<reportElement uuid="f2a5527b-8cd4-43db-8533-09be16611c78" stretchType="RelativeToTallestObject" x="479" y="13" width="1" height="22"/>
+					<reportElement stretchType="ElementGroupHeight" x="479" y="13" width="1" height="22" uuid="f2a5527b-8cd4-43db-8533-09be16611c78"/>
 					<graphicElement>
 						<pen lineWidth="0.25"/>
 					</graphicElement>
 				</line>
 				<line>
-					<reportElement uuid="f2a5527b-8cd4-43db-8533-09be16611c78" stretchType="RelativeToTallestObject" x="629" y="13" width="1" height="22"/>
+					<reportElement stretchType="ElementGroupHeight" x="629" y="13" width="1" height="22" uuid="f2a5527b-8cd4-43db-8533-09be16611c78"/>
 					<graphicElement>
 						<pen lineWidth="0.25"/>
 					</graphicElement>
 				</line>
 				<staticText>
-					<reportElement uuid="facc719d-be98-44a7-b6d1-83d78470c015" x="345" y="14" width="60" height="12"/>
+					<reportElement x="345" y="14" width="60" height="12" uuid="facc719d-be98-44a7-b6d1-83d78470c015"/>
 					<textElement markup="none">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[Turno]]></text>
 				</staticText>
 				<staticText>
-					<reportElement uuid="6953c7f5-6d0d-4a40-97f1-2b04a826cab0" x="485" y="14" width="60" height="12"/>
+					<reportElement x="485" y="14" width="60" height="12" uuid="6953c7f5-6d0d-4a40-97f1-2b04a826cab0"/>
 					<textElement markup="none">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[Turma]]></text>
 				</staticText>
 				<staticText>
-					<reportElement uuid="91f84f15-ac29-480d-b059-2ff8bcd6b901" x="635" y="14" width="84" height="12"/>
+					<reportElement x="635" y="14" width="84" height="12" uuid="91f84f15-ac29-480d-b059-2ff8bcd6b901"/>
 					<textElement markup="none">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
@@ -190,35 +191,35 @@
 				</staticText>
 				<elementGroup/>
 				<textField isStretchWithOverflow="true">
-					<reportElement uuid="d7cb064f-ead8-42d0-9fcc-6af162fb9f3f" stretchType="RelativeToTallestObject" x="10" y="24" width="159" height="11"/>
+					<reportElement stretchType="ElementGroupHeight" x="10" y="24" width="159" height="11" uuid="d7cb064f-ead8-42d0-9fcc-6af162fb9f3f"/>
 					<textElement verticalAlignment="Bottom">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{nm_curso}]]></textFieldExpression>
 				</textField>
 				<textField>
-					<reportElement uuid="ac5b81b3-5dc6-48f5-bd73-db0b4768058b" x="175" y="13" width="164" height="22"/>
+					<reportElement x="175" y="13" width="164" height="22" uuid="ac5b81b3-5dc6-48f5-bd73-db0b4768058b"/>
 					<textElement verticalAlignment="Bottom">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{nm_serie}]]></textFieldExpression>
 				</textField>
 				<textField>
-					<reportElement uuid="36be69db-91d4-456a-bfab-bab8b4d4d7c1" x="345" y="13" width="134" height="22"/>
+					<reportElement x="345" y="13" width="134" height="22" uuid="36be69db-91d4-456a-bfab-bab8b4d4d7c1"/>
 					<textElement verticalAlignment="Bottom">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{turno_turma}]]></textFieldExpression>
 				</textField>
 				<textField>
-					<reportElement uuid="30134ac3-5a56-47ed-a864-b6d7f3cc4008" x="485" y="13" width="145" height="22"/>
+					<reportElement x="485" y="13" width="145" height="22" uuid="30134ac3-5a56-47ed-a864-b6d7f3cc4008"/>
 					<textElement verticalAlignment="Bottom">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{nm_turma}]]></textFieldExpression>
 				</textField>
 				<textField>
-					<reportElement uuid="fa949fd7-bcea-470e-891e-d332f556ffbf" x="635" y="13" width="143" height="22"/>
+					<reportElement x="635" y="13" width="143" height="22" uuid="fa949fd7-bcea-470e-891e-d332f556ffbf"/>
 					<box>
 						<bottomPen lineWidth="0.0"/>
 						<rightPen lineWidth="0.0"/>
@@ -233,38 +234,38 @@
 		<groupFooter>
 			<band height="185">
 				<crosstab columnBreakOffset="0" ignoreWidth="false">
-					<reportElement uuid="0f045964-8ec7-4fdf-8410-2e62d650f0ec" x="0" y="0" width="783" height="185">
+					<reportElement x="0" y="0" width="783" height="185" uuid="0f045964-8ec7-4fdf-8410-2e62d650f0ec">
 						<printWhenExpression><![CDATA[$F{usa_media_geral}]]></printWhenExpression>
 					</reportElement>
 					<crosstabDataset isDataPreSorted="true"/>
 					<crosstabHeaderCell>
 						<cellContents>
 							<rectangle radius="0">
-								<reportElement uuid="9c6062f1-4a12-4a0e-b078-d26686e79732" style="Crosstab Data Text" x="0" y="0" width="418" height="110" backcolor="#E7E7E7"/>
+								<reportElement style="Crosstab Data Text" x="0" y="0" width="418" height="110" backcolor="#E7E7E7" uuid="9c6062f1-4a12-4a0e-b078-d26686e79732"/>
 								<graphicElement>
 									<pen lineWidth="0.25"/>
 								</graphicElement>
 							</rectangle>
 							<rectangle>
-								<reportElement uuid="cc722808-4065-45eb-8a28-f3d463d58b16" style="Crosstab Data Text" x="0" y="110" width="418" height="11" backcolor="#E7E7E7"/>
+								<reportElement style="Crosstab Data Text" x="0" y="110" width="418" height="11" backcolor="#E7E7E7" uuid="cc722808-4065-45eb-8a28-f3d463d58b16"/>
 								<graphicElement>
 									<pen lineWidth="0.25"/>
 								</graphicElement>
 							</rectangle>
 							<rectangle>
-								<reportElement uuid="b5a36ae1-6ea4-4769-a2a1-ec0d54d38c0f" style="Crosstab Data Text" x="323" y="0" width="95" height="121" backcolor="#E7E7E7"/>
+								<reportElement style="Crosstab Data Text" x="323" y="0" width="95" height="121" backcolor="#E7E7E7" uuid="b5a36ae1-6ea4-4769-a2a1-ec0d54d38c0f"/>
 								<graphicElement>
 									<pen lineWidth="0.25"/>
 								</graphicElement>
 							</rectangle>
 							<rectangle>
-								<reportElement uuid="cc722808-4065-45eb-8a28-f3d463d58b16" style="Crosstab Data Text" x="357" y="0" width="25" height="121" backcolor="#E7E7E7"/>
+								<reportElement style="Crosstab Data Text" x="357" y="0" width="25" height="121" backcolor="#E7E7E7" uuid="cc722808-4065-45eb-8a28-f3d463d58b16"/>
 								<graphicElement>
 									<pen lineWidth="0.25"/>
 								</graphicElement>
 							</rectangle>
 							<staticText>
-								<reportElement uuid="326dfc11-9f58-4955-aca7-ad5fbdd28363" style="Crosstab Data Text" x="382" y="0" width="36" height="110"/>
+								<reportElement style="Crosstab Data Text" x="382" y="0" width="36" height="110" uuid="326dfc11-9f58-4955-aca7-ad5fbdd28363"/>
 								<box>
 									<bottomPen lineWidth="0.25"/>
 								</box>
@@ -275,21 +276,21 @@
 								<text><![CDATA[Disciplinas Ministradas]]></text>
 							</staticText>
 							<staticText>
-								<reportElement uuid="5284b536-946b-4c87-a783-1ebd0cb146cb" style="Crosstab Data Text" x="2" y="110" width="231" height="10"/>
+								<reportElement style="Crosstab Data Text" x="2" y="110" width="231" height="10" uuid="5284b536-946b-4c87-a783-1ebd0cb146cb"/>
 								<textElement textAlignment="Left" verticalAlignment="Middle">
 									<font fontName="DejaVu Sans" size="8"/>
 								</textElement>
 								<text><![CDATA[Nome do aluno]]></text>
 							</staticText>
 							<staticText>
-								<reportElement uuid="2bee4445-3286-4f48-8d57-1bab3d11e764" style="Crosstab Data Text" x="382" y="110" width="36" height="10"/>
+								<reportElement style="Crosstab Data Text" x="382" y="110" width="36" height="10" uuid="2bee4445-3286-4f48-8d57-1bab3d11e764"/>
 								<textElement textAlignment="Center" verticalAlignment="Middle">
 									<font fontName="DejaVu Sans" size="8"/>
 								</textElement>
 								<text><![CDATA[C.H.]]></text>
 							</staticText>
 							<staticText>
-								<reportElement uuid="de716f6b-64b5-40c8-930f-48b20b6bd749" style="Crosstab Data Text" stretchType="RelativeToTallestObject" x="323" y="0" width="34" height="110"/>
+								<reportElement style="Crosstab Data Text" stretchType="ElementGroupHeight" x="323" y="0" width="34" height="110" uuid="de716f6b-64b5-40c8-930f-48b20b6bd749"/>
 								<box>
 									<bottomPen lineWidth="0.25"/>
 								</box>
@@ -301,7 +302,7 @@
     e freq. global]]></text>
 							</staticText>
 							<staticText>
-								<reportElement uuid="de716f6b-64b5-40c8-930f-48b20b6bd749" style="Crosstab Data Text" stretchType="RelativeToTallestObject" x="357" y="0" width="25" height="110"/>
+								<reportElement style="Crosstab Data Text" stretchType="ElementGroupHeight" x="357" y="0" width="25" height="110" uuid="de716f6b-64b5-40c8-930f-48b20b6bd749"/>
 								<box>
 									<bottomPen lineWidth="0.25"/>
 								</box>
@@ -312,7 +313,7 @@
 								<text><![CDATA[Média Global]]></text>
 							</staticText>
 							<staticText>
-								<reportElement uuid="7ad0c738-9ed9-423b-a3d2-2042ceb84a24" style="Crosstab Data Text" x="233" y="110" width="88" height="10"/>
+								<reportElement style="Crosstab Data Text" x="233" y="110" width="88" height="10" uuid="7ad0c738-9ed9-423b-a3d2-2042ceb84a24"/>
 								<textElement textAlignment="Right" verticalAlignment="Middle">
 									<font fontName="DejaVu Sans" size="6"/>
 								</textElement>
@@ -333,7 +334,7 @@
 									<rightPen lineWidth="0.25"/>
 								</box>
 								<rectangle>
-									<reportElement uuid="b0d7e223-b609-4a75-8e07-0f352c2280e6" style="Crosstab Data Text" x="0" y="0" width="418" height="21">
+									<reportElement style="Crosstab Data Text" x="0" y="0" width="418" height="21" uuid="b0d7e223-b609-4a75-8e07-0f352c2280e6">
 										<printWhenExpression><![CDATA[new Boolean(($V{COLUMN_COUNT} % 2) == 1)]]></printWhenExpression>
 									</reportElement>
 									<graphicElement>
@@ -341,7 +342,7 @@
 									</graphicElement>
 								</rectangle>
 								<textField>
-									<reportElement uuid="2d62bf87-fd79-4cbe-b9e1-4f80d50bb5fc" style="linha-zebrado" mode="Opaque" x="0" y="0" width="233" height="21"/>
+									<reportElement style="linha-zebrado" mode="Opaque" x="0" y="0" width="233" height="21" uuid="2d62bf87-fd79-4cbe-b9e1-4f80d50bb5fc"/>
 									<box leftPadding="2"/>
 									<textElement textAlignment="Left" verticalAlignment="Middle">
 										<font fontName="DejaVu Sans" size="8"/>
@@ -349,7 +350,7 @@
 									<textFieldExpression><![CDATA[$V{nm_aluno}]]></textFieldExpression>
 								</textField>
 								<staticText>
-									<reportElement uuid="f6348606-9b9b-49f5-9dd9-f80b7fd0f95a" style="linha-zebrado" mode="Opaque" x="382" y="0" width="36" height="11"/>
+									<reportElement style="linha-zebrado" mode="Opaque" x="382" y="0" width="36" height="11" uuid="f6348606-9b9b-49f5-9dd9-f80b7fd0f95a"/>
 									<box>
 										<leftPen lineWidth="0.25"/>
 									</box>
@@ -359,7 +360,7 @@
 									<text><![CDATA[Nota]]></text>
 								</staticText>
 								<staticText>
-									<reportElement uuid="2416214e-065a-47cb-9675-37f1f53e8a22" style="linha-zebrado" mode="Opaque" x="382" y="10" width="36" height="11"/>
+									<reportElement style="linha-zebrado" mode="Opaque" x="382" y="10" width="36" height="11" uuid="2416214e-065a-47cb-9675-37f1f53e8a22"/>
 									<box>
 										<leftPen lineWidth="0.25"/>
 									</box>
@@ -369,7 +370,7 @@
 									<text><![CDATA[Faltas]]></text>
 								</staticText>
 								<textField pattern="###" isBlankWhenNull="true">
-									<reportElement uuid="85db04cb-ca6b-4aa1-931e-3a34f31b92ae" style="linha-zebrado" mode="Opaque" x="357" y="0" width="25" height="21"/>
+									<reportElement style="linha-zebrado" mode="Opaque" x="357" y="0" width="25" height="21" uuid="85db04cb-ca6b-4aa1-931e-3a34f31b92ae"/>
 									<box>
 										<rightPen lineWidth="0.25"/>
 									</box>
@@ -379,7 +380,7 @@
 									<textFieldExpression><![CDATA[$V{media_geral} == null || $V{situacao}.equals("Trs") || $V{situacao}.equals("Aba") ?  " - " : $V{media_geral}]]></textFieldExpression>
 								</textField>
 								<textField isBlankWhenNull="true">
-									<reportElement uuid="53d680c6-c629-4588-a7df-5c16427abbe7" style="linha-zebrado" mode="Opaque" x="323" y="10" width="34" height="11"/>
+									<reportElement style="linha-zebrado" mode="Opaque" x="323" y="10" width="34" height="11" uuid="53d680c6-c629-4588-a7df-5c16427abbe7"/>
 									<box>
 										<leftPen lineWidth="0.25"/>
 										<rightPen lineWidth="0.25"/>
@@ -390,7 +391,7 @@
 									<textFieldExpression><![CDATA[$V{frequencia} == null || $V{situacao} == "Trs" || $V{situacao} == "Aba" ?  " - "  : new DecimalFormat("####0.0").format($V{frequencia}) + "%"]]></textFieldExpression>
 								</textField>
 								<textField>
-									<reportElement uuid="d8a07e80-2412-45f9-ac98-5415c91fa756" style="linha-zebrado" mode="Opaque" x="323" y="0" width="34" height="11"/>
+									<reportElement style="linha-zebrado" mode="Opaque" x="323" y="0" width="34" height="11" uuid="d8a07e80-2412-45f9-ac98-5415c91fa756"/>
 									<box>
 										<leftPen lineWidth="0.25"/>
 										<rightPen lineWidth="0.25"/>
@@ -401,7 +402,7 @@
 									<textFieldExpression><![CDATA[$V{situacao}]]></textFieldExpression>
 								</textField>
 								<textField>
-									<reportElement uuid="36ed0bc9-3968-47ab-8250-4b1e7afa7399" style="linha-zebrado" mode="Opaque" x="232" y="0" width="91" height="21"/>
+									<reportElement style="linha-zebrado" mode="Opaque" x="232" y="0" width="91" height="21" uuid="36ed0bc9-3968-47ab-8250-4b1e7afa7399"/>
 									<box rightPadding="2">
 										<rightPen lineWidth="0.25"/>
 									</box>
@@ -429,7 +430,7 @@
 									<rightPen lineWidth="0.25"/>
 								</box>
 								<textField>
-									<reportElement uuid="7dde05f5-d91c-4e61-aedc-7b732ea48094" style="Crosstab Data Text" x="0" y="0" width="30" height="110"/>
+									<reportElement style="Crosstab Data Text" x="0" y="0" width="30" height="110" uuid="7dde05f5-d91c-4e61-aedc-7b732ea48094"/>
 									<box>
 										<bottomPen lineWidth="0.25"/>
 									</box>
@@ -440,7 +441,7 @@
 									<textFieldExpression><![CDATA[$V{componente_curricular} == null ? " -  " : $V{componente_curricular}]]></textFieldExpression>
 								</textField>
 								<textField>
-									<reportElement uuid="b1096632-5ed7-4185-9e14-61dbc938341b" x="0" y="110" width="30" height="10"/>
+									<reportElement x="0" y="110" width="30" height="10" uuid="b1096632-5ed7-4185-9e14-61dbc938341b"/>
 									<textElement textAlignment="Center" verticalAlignment="Middle">
 										<font fontName="DejaVu Sans" size="8"/>
 									</textElement>
@@ -482,7 +483,7 @@
 					<crosstabCell width="30" height="21">
 						<cellContents>
 							<textField>
-								<reportElement uuid="9d614647-7929-4b26-94c1-f96f54422b39" style="linha-zebrado" mode="Opaque" x="0" y="0" width="30" height="11"/>
+								<reportElement style="linha-zebrado" mode="Opaque" x="0" y="0" width="30" height="11" uuid="9d614647-7929-4b26-94c1-f96f54422b39"/>
 								<box>
 									<topPen lineWidth="0.25"/>
 									<leftPen lineWidth="0.25"/>
@@ -494,7 +495,7 @@
 								<textFieldExpression><![CDATA[$V{situacao} == "Trs" || $V{situacao} == "Aba"  ? "-" : $V{notaMeasure}]]></textFieldExpression>
 							</textField>
 							<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-								<reportElement uuid="57bcd6eb-e1e8-4daa-a6e2-ed8273c6e89a" style="linha-zebrado" mode="Opaque" x="0" y="10" width="30" height="11"/>
+								<reportElement style="linha-zebrado" mode="Opaque" x="0" y="10" width="30" height="11" uuid="57bcd6eb-e1e8-4daa-a6e2-ed8273c6e89a"/>
 								<box>
 									<leftPen lineWidth="0.25"/>
 									<bottomPen lineWidth="0.25"/>
@@ -510,8 +511,7 @@
 					<crosstabCell height="25" rowTotalGroup="aluno">
 						<cellContents backcolor="#BFE1FF" mode="Opaque">
 							<textField>
-								<reportElement uuid="21407fe9-1114-457c-8aee-cbdcb1736f6a" style="Crosstab Data Text" x="0" y="0" width="50" height="25"/>
-								<textElement/>
+								<reportElement style="Crosstab Data Text" x="0" y="0" width="50" height="25" uuid="21407fe9-1114-457c-8aee-cbdcb1736f6a"/>
 								<textFieldExpression><![CDATA[$V{notaMeasure}]]></textFieldExpression>
 							</textField>
 						</cellContents>
@@ -519,8 +519,7 @@
 					<crosstabCell width="50" columnTotalGroup="componente_curricular">
 						<cellContents backcolor="#BFE1FF" mode="Opaque">
 							<textField>
-								<reportElement uuid="d6b5d082-d63d-40ca-9f2a-9bdb9703c715" style="Crosstab Data Text" x="0" y="0" width="50" height="25"/>
-								<textElement/>
+								<reportElement style="Crosstab Data Text" x="0" y="0" width="50" height="25" uuid="d6b5d082-d63d-40ca-9f2a-9bdb9703c715"/>
 								<textFieldExpression><![CDATA[$V{notaMeasure}]]></textFieldExpression>
 							</textField>
 						</cellContents>
@@ -528,46 +527,45 @@
 					<crosstabCell rowTotalGroup="aluno" columnTotalGroup="componente_curricular">
 						<cellContents backcolor="#BFE1FF" mode="Opaque">
 							<textField>
-								<reportElement uuid="fe8cfc4c-d50e-43c2-b393-3f7a8ff10fe0" style="Crosstab Data Text" x="0" y="0" width="50" height="25"/>
-								<textElement/>
+								<reportElement style="Crosstab Data Text" x="0" y="0" width="50" height="25" uuid="fe8cfc4c-d50e-43c2-b393-3f7a8ff10fe0"/>
 								<textFieldExpression><![CDATA[$V{notaMeasure}]]></textFieldExpression>
 							</textField>
 						</cellContents>
 					</crosstabCell>
 				</crosstab>
 				<crosstab columnBreakOffset="0" ignoreWidth="false">
-					<reportElement uuid="0f045964-8ec7-4fdf-8410-2e62d650f0ec" x="0" y="0" width="783" height="185">
+					<reportElement x="0" y="0" width="783" height="185" uuid="0f045964-8ec7-4fdf-8410-2e62d650f0ec">
 						<printWhenExpression><![CDATA[!$F{usa_media_geral}]]></printWhenExpression>
 					</reportElement>
 					<crosstabDataset isDataPreSorted="true"/>
 					<crosstabHeaderCell>
 						<cellContents>
 							<rectangle radius="0">
-								<reportElement uuid="9c6062f1-4a12-4a0e-b078-d26686e79732" style="Crosstab Data Text" x="0" y="0" width="418" height="110" backcolor="#E7E7E7"/>
+								<reportElement style="Crosstab Data Text" x="0" y="0" width="418" height="110" backcolor="#E7E7E7" uuid="9c6062f1-4a12-4a0e-b078-d26686e79732"/>
 								<graphicElement>
 									<pen lineWidth="0.25"/>
 								</graphicElement>
 							</rectangle>
 							<rectangle>
-								<reportElement uuid="cc722808-4065-45eb-8a28-f3d463d58b16" style="Crosstab Data Text" x="0" y="110" width="418" height="11" backcolor="#E7E7E7"/>
+								<reportElement style="Crosstab Data Text" x="0" y="110" width="418" height="11" backcolor="#E7E7E7" uuid="cc722808-4065-45eb-8a28-f3d463d58b16"/>
 								<graphicElement>
 									<pen lineWidth="0.25"/>
 								</graphicElement>
 							</rectangle>
 							<rectangle>
-								<reportElement uuid="b5a36ae1-6ea4-4769-a2a1-ec0d54d38c0f" style="Crosstab Data Text" x="323" y="0" width="95" height="121" backcolor="#E7E7E7"/>
+								<reportElement style="Crosstab Data Text" x="323" y="0" width="95" height="121" backcolor="#E7E7E7" uuid="b5a36ae1-6ea4-4769-a2a1-ec0d54d38c0f"/>
 								<graphicElement>
 									<pen lineWidth="0.25"/>
 								</graphicElement>
 							</rectangle>
 							<rectangle>
-								<reportElement uuid="cc722808-4065-45eb-8a28-f3d463d58b16" style="Crosstab Data Text" x="323" y="0" width="42" height="121" backcolor="#E7E7E7"/>
+								<reportElement style="Crosstab Data Text" x="323" y="0" width="42" height="121" backcolor="#E7E7E7" uuid="cc722808-4065-45eb-8a28-f3d463d58b16"/>
 								<graphicElement>
 									<pen lineWidth="0.25"/>
 								</graphicElement>
 							</rectangle>
 							<staticText>
-								<reportElement uuid="326dfc11-9f58-4955-aca7-ad5fbdd28363" style="Crosstab Data Text" x="365" y="0" width="53" height="110"/>
+								<reportElement style="Crosstab Data Text" x="365" y="0" width="53" height="110" uuid="326dfc11-9f58-4955-aca7-ad5fbdd28363"/>
 								<box>
 									<bottomPen lineWidth="0.25"/>
 								</box>
@@ -578,21 +576,21 @@
 								<text><![CDATA[Disciplinas Ministradas]]></text>
 							</staticText>
 							<staticText>
-								<reportElement uuid="5284b536-946b-4c87-a783-1ebd0cb146cb" style="Crosstab Data Text" x="2" y="110" width="231" height="10"/>
+								<reportElement style="Crosstab Data Text" x="2" y="110" width="231" height="10" uuid="5284b536-946b-4c87-a783-1ebd0cb146cb"/>
 								<textElement textAlignment="Left" verticalAlignment="Middle">
 									<font fontName="DejaVu Sans" size="8"/>
 								</textElement>
 								<text><![CDATA[Nome do aluno]]></text>
 							</staticText>
 							<staticText>
-								<reportElement uuid="2bee4445-3286-4f48-8d57-1bab3d11e764" style="Crosstab Data Text" x="365" y="110" width="53" height="10"/>
+								<reportElement style="Crosstab Data Text" x="365" y="110" width="53" height="10" uuid="2bee4445-3286-4f48-8d57-1bab3d11e764"/>
 								<textElement textAlignment="Center" verticalAlignment="Middle">
 									<font fontName="DejaVu Sans" size="8"/>
 								</textElement>
 								<text><![CDATA[C.H.]]></text>
 							</staticText>
 							<staticText>
-								<reportElement uuid="de716f6b-64b5-40c8-930f-48b20b6bd749" style="Crosstab Data Text" stretchType="RelativeToTallestObject" x="323" y="0" width="42" height="110"/>
+								<reportElement style="Crosstab Data Text" stretchType="ElementGroupHeight" x="323" y="0" width="42" height="110" uuid="de716f6b-64b5-40c8-930f-48b20b6bd749"/>
 								<box>
 									<bottomPen lineWidth="0.25"/>
 								</box>
@@ -604,7 +602,7 @@
     e freq. global]]></text>
 							</staticText>
 							<staticText>
-								<reportElement uuid="de716f6b-64b5-40c8-930f-48b20b6bd749" style="Crosstab Data Text" stretchType="RelativeToTallestObject" x="323" y="0" width="0" height="121"/>
+								<reportElement style="Crosstab Data Text" stretchType="ElementGroupHeight" x="323" y="0" width="0" height="121" uuid="de716f6b-64b5-40c8-930f-48b20b6bd749"/>
 								<box>
 									<bottomPen lineWidth="0.25"/>
 								</box>
@@ -615,7 +613,7 @@
 								<text><![CDATA[]]></text>
 							</staticText>
 							<staticText>
-								<reportElement uuid="7ad0c738-9ed9-423b-a3d2-2042ceb84a24" style="Crosstab Data Text" x="233" y="110" width="88" height="10"/>
+								<reportElement style="Crosstab Data Text" x="233" y="110" width="88" height="10" uuid="7ad0c738-9ed9-423b-a3d2-2042ceb84a24"/>
 								<textElement textAlignment="Right" verticalAlignment="Middle">
 									<font fontName="DejaVu Sans" size="6"/>
 								</textElement>
@@ -636,7 +634,7 @@
 									<rightPen lineWidth="0.25"/>
 								</box>
 								<rectangle>
-									<reportElement uuid="b0d7e223-b609-4a75-8e07-0f352c2280e6" style="Crosstab Data Text" x="0" y="0" width="418" height="21">
+									<reportElement style="Crosstab Data Text" x="0" y="0" width="418" height="21" uuid="b0d7e223-b609-4a75-8e07-0f352c2280e6">
 										<printWhenExpression><![CDATA[new Boolean(($V{COLUMN_COUNT} % 2) == 1)]]></printWhenExpression>
 									</reportElement>
 									<graphicElement>
@@ -644,7 +642,7 @@
 									</graphicElement>
 								</rectangle>
 								<textField>
-									<reportElement uuid="2d62bf87-fd79-4cbe-b9e1-4f80d50bb5fc" style="linha-zebrado" mode="Opaque" x="0" y="0" width="233" height="21"/>
+									<reportElement style="linha-zebrado" mode="Opaque" x="0" y="0" width="233" height="21" uuid="2d62bf87-fd79-4cbe-b9e1-4f80d50bb5fc"/>
 									<box leftPadding="2"/>
 									<textElement textAlignment="Left" verticalAlignment="Middle">
 										<font fontName="DejaVu Sans" size="8"/>
@@ -652,7 +650,7 @@
 									<textFieldExpression><![CDATA[$V{nm_aluno}]]></textFieldExpression>
 								</textField>
 								<staticText>
-									<reportElement uuid="f6348606-9b9b-49f5-9dd9-f80b7fd0f95a" style="linha-zebrado" mode="Opaque" x="365" y="0" width="53" height="11"/>
+									<reportElement style="linha-zebrado" mode="Opaque" x="365" y="0" width="53" height="11" uuid="f6348606-9b9b-49f5-9dd9-f80b7fd0f95a"/>
 									<box>
 										<leftPen lineWidth="0.25"/>
 									</box>
@@ -662,7 +660,7 @@
 									<text><![CDATA[Nota]]></text>
 								</staticText>
 								<staticText>
-									<reportElement uuid="2416214e-065a-47cb-9675-37f1f53e8a22" style="linha-zebrado" mode="Opaque" x="365" y="10" width="53" height="11"/>
+									<reportElement style="linha-zebrado" mode="Opaque" x="365" y="10" width="53" height="11" uuid="2416214e-065a-47cb-9675-37f1f53e8a22"/>
 									<box>
 										<leftPen lineWidth="0.25"/>
 									</box>
@@ -672,7 +670,7 @@
 									<text><![CDATA[Faltas]]></text>
 								</staticText>
 								<textField pattern="###" isBlankWhenNull="true">
-									<reportElement uuid="85db04cb-ca6b-4aa1-931e-3a34f31b92ae" style="linha-zebrado" mode="Opaque" x="357" y="0" width="8" height="21"/>
+									<reportElement style="linha-zebrado" mode="Opaque" x="357" y="0" width="8" height="21" uuid="85db04cb-ca6b-4aa1-931e-3a34f31b92ae"/>
 									<box>
 										<rightPen lineWidth="0.25"/>
 									</box>
@@ -681,7 +679,7 @@
 									</textElement>
 								</textField>
 								<textField isBlankWhenNull="true">
-									<reportElement uuid="53d680c6-c629-4588-a7df-5c16427abbe7" style="linha-zebrado" mode="Opaque" x="323" y="10" width="42" height="11"/>
+									<reportElement style="linha-zebrado" mode="Opaque" x="323" y="10" width="42" height="11" uuid="53d680c6-c629-4588-a7df-5c16427abbe7"/>
 									<box>
 										<leftPen lineWidth="0.25"/>
 										<rightPen lineWidth="0.25"/>
@@ -692,7 +690,7 @@
 									<textFieldExpression><![CDATA[$V{frequencia} == null || $V{situacao} == "Trs" || $V{situacao} == "Aba"  ?  " - "  : new DecimalFormat("####0.0").format($V{frequencia}) + "%"]]></textFieldExpression>
 								</textField>
 								<textField>
-									<reportElement uuid="d8a07e80-2412-45f9-ac98-5415c91fa756" style="linha-zebrado" mode="Opaque" x="323" y="0" width="42" height="11"/>
+									<reportElement style="linha-zebrado" mode="Opaque" x="323" y="0" width="42" height="11" uuid="d8a07e80-2412-45f9-ac98-5415c91fa756"/>
 									<box>
 										<leftPen lineWidth="0.25"/>
 										<rightPen lineWidth="0.25"/>
@@ -703,7 +701,7 @@
 									<textFieldExpression><![CDATA[$V{situacao}]]></textFieldExpression>
 								</textField>
 								<textField>
-									<reportElement uuid="36ed0bc9-3968-47ab-8250-4b1e7afa7399" style="linha-zebrado" mode="Opaque" x="232" y="0" width="91" height="21"/>
+									<reportElement style="linha-zebrado" mode="Opaque" x="232" y="0" width="91" height="21" uuid="36ed0bc9-3968-47ab-8250-4b1e7afa7399"/>
 									<box rightPadding="2">
 										<rightPen lineWidth="0.25"/>
 									</box>
@@ -731,7 +729,7 @@
 									<rightPen lineWidth="0.25"/>
 								</box>
 								<textField>
-									<reportElement uuid="7dde05f5-d91c-4e61-aedc-7b732ea48094" style="Crosstab Data Text" x="0" y="0" width="30" height="110"/>
+									<reportElement style="Crosstab Data Text" x="0" y="0" width="30" height="110" uuid="7dde05f5-d91c-4e61-aedc-7b732ea48094"/>
 									<box>
 										<bottomPen lineWidth="0.25"/>
 									</box>
@@ -742,7 +740,7 @@
 									<textFieldExpression><![CDATA[$V{componente_curricular} == null ? " -  " : $V{componente_curricular}]]></textFieldExpression>
 								</textField>
 								<textField>
-									<reportElement uuid="b1096632-5ed7-4185-9e14-61dbc938341b" x="0" y="110" width="30" height="10"/>
+									<reportElement x="0" y="110" width="30" height="10" uuid="b1096632-5ed7-4185-9e14-61dbc938341b"/>
 									<textElement textAlignment="Center" verticalAlignment="Middle">
 										<font fontName="DejaVu Sans" size="8"/>
 									</textElement>
@@ -755,7 +753,11 @@
 						</crosstabTotalColumnHeader>
 					</columnGroup>
 					<measure name="notaMeasure" class="java.lang.String">
-						<measureExpression><![CDATA[$F{nota} == null ? " - " : String.format(java.util.Locale.US, "%.1f", Double.parseDouble($F{nota}))]]></measureExpression>
+						<measureExpression><![CDATA[$F{nota} == null
+							    ? " - "
+							    : ($F{nota}.matches(".*[a-zA-Z].*")
+							        ? $F{nota}
+							        : String.format(java.util.Locale.US, "%.1f", Double.parseDouble($F{nota})))]]></measureExpression>
 					</measure>
 					<measure name="count_aluno" class="java.lang.Integer">
 						<measureExpression><![CDATA[$F{aluno}]]></measureExpression>
@@ -784,7 +786,7 @@
 					<crosstabCell width="30" height="22">
 						<cellContents>
 							<textField>
-								<reportElement uuid="9d614647-7929-4b26-94c1-f96f54422b39" style="linha-zebrado" mode="Opaque" x="0" y="0" width="30" height="11"/>
+								<reportElement style="linha-zebrado" mode="Opaque" x="0" y="0" width="30" height="11" uuid="9d614647-7929-4b26-94c1-f96f54422b39"/>
 								<box>
 									<topPen lineWidth="0.25"/>
 									<leftPen lineWidth="0.25"/>
@@ -796,7 +798,7 @@
 								<textFieldExpression><![CDATA[$V{situacao} == "Trs" || $V{situacao} == "Aba"  ? "-" : $V{notaMeasure}]]></textFieldExpression>
 							</textField>
 							<textField isStretchWithOverflow="true" isBlankWhenNull="true">
-								<reportElement uuid="57bcd6eb-e1e8-4daa-a6e2-ed8273c6e89a" style="linha-zebrado" mode="Opaque" x="0" y="10" width="30" height="11"/>
+								<reportElement style="linha-zebrado" mode="Opaque" x="0" y="10" width="30" height="11" uuid="57bcd6eb-e1e8-4daa-a6e2-ed8273c6e89a"/>
 								<box>
 									<leftPen lineWidth="0.25"/>
 									<bottomPen lineWidth="0.25"/>
@@ -812,8 +814,7 @@
 					<crosstabCell height="25" rowTotalGroup="aluno">
 						<cellContents backcolor="#BFE1FF" mode="Opaque">
 							<textField>
-								<reportElement uuid="21407fe9-1114-457c-8aee-cbdcb1736f6a" style="Crosstab Data Text" x="0" y="0" width="50" height="25"/>
-								<textElement/>
+								<reportElement style="Crosstab Data Text" x="0" y="0" width="50" height="25" uuid="21407fe9-1114-457c-8aee-cbdcb1736f6a"/>
 								<textFieldExpression><![CDATA[$V{notaMeasure}]]></textFieldExpression>
 							</textField>
 						</cellContents>
@@ -821,8 +822,7 @@
 					<crosstabCell width="50" columnTotalGroup="componente_curricular">
 						<cellContents backcolor="#BFE1FF" mode="Opaque">
 							<textField>
-								<reportElement uuid="d6b5d082-d63d-40ca-9f2a-9bdb9703c715" style="Crosstab Data Text" x="0" y="0" width="50" height="25"/>
-								<textElement/>
+								<reportElement style="Crosstab Data Text" x="0" y="0" width="50" height="25" uuid="d6b5d082-d63d-40ca-9f2a-9bdb9703c715"/>
 								<textFieldExpression><![CDATA[$V{notaMeasure}]]></textFieldExpression>
 							</textField>
 						</cellContents>
@@ -830,8 +830,7 @@
 					<crosstabCell rowTotalGroup="aluno" columnTotalGroup="componente_curricular">
 						<cellContents backcolor="#BFE1FF" mode="Opaque">
 							<textField>
-								<reportElement uuid="fe8cfc4c-d50e-43c2-b393-3f7a8ff10fe0" style="Crosstab Data Text" x="0" y="0" width="50" height="25"/>
-								<textElement/>
+								<reportElement style="Crosstab Data Text" x="0" y="0" width="50" height="25" uuid="fe8cfc4c-d50e-43c2-b393-3f7a8ff10fe0"/>
 								<textFieldExpression><![CDATA[$V{notaMeasure}]]></textFieldExpression>
 							</textField>
 						</cellContents>
@@ -846,7 +845,7 @@
 	<title>
 		<band height="79" splitType="Stretch">
 			<subreport>
-				<reportElement uuid="a84c55f4-2125-495f-9694-6d29f88ebe4d" x="0" y="0" width="740" height="79"/>
+				<reportElement x="0" y="0" width="740" height="79" uuid="a84c55f4-2125-495f-9694-6d29f88ebe4d"/>
 				<subreportParameter name="logo">
 					<subreportParameterExpression><![CDATA[$P{logo}]]></subreportParameterExpression>
 				</subreportParameter>
@@ -876,14 +875,14 @@
 	<pageFooter>
 		<band height="11">
 			<textField>
-				<reportElement uuid="efb657d7-cf1a-4682-b1b5-3f003bbf0b99" x="673" y="0" width="92" height="11"/>
+				<reportElement x="673" y="0" width="92" height="11" uuid="efb657d7-cf1a-4682-b1b5-3f003bbf0b99"/>
 				<textElement textAlignment="Right" markup="html">
 					<font fontName="DejaVu Sans" size="7" isBold="false"/>
 				</textElement>
 				<textFieldExpression><![CDATA["Página: " + $V{PAGE_NUMBER} +" de "]]></textFieldExpression>
 			</textField>
 			<textField evaluationTime="Report">
-				<reportElement uuid="4b84c028-0fba-4d3c-bc46-c7af40e378f3" x="765" y="0" width="13" height="11"/>
+				<reportElement x="765" y="0" width="13" height="11" uuid="4b84c028-0fba-4d3c-bc46-c7af40e378f3"/>
 				<textElement>
 					<font fontName="DejaVu Sans" size="7"/>
 				</textElement>
@@ -894,7 +893,7 @@
 	<lastPageFooter>
 		<band height="320" splitType="Stretch">
 			<staticText>
-				<reportElement uuid="64c8c95f-a624-4f17-83c9-77976f109951" stretchType="RelativeToBandHeight" x="0" y="247" width="233" height="20" isPrintWhenDetailOverflows="true"/>
+				<reportElement stretchType="ContainerHeight" x="0" y="247" width="233" height="20" isPrintWhenDetailOverflows="true" uuid="64c8c95f-a624-4f17-83c9-77976f109951"/>
 				<box>
 					<topPen lineWidth="0.25"/>
 				</box>
@@ -904,7 +903,7 @@
 				<text><![CDATA[Assinatura do(a) funcionário(a) - nº reg. ou aut.]]></text>
 			</staticText>
 			<staticText>
-				<reportElement uuid="8c2f723b-dfe1-41e6-be85-0f59e664b60f" stretchType="RelativeToBandHeight" x="545" y="247" width="233" height="20" isPrintWhenDetailOverflows="true"/>
+				<reportElement stretchType="ContainerHeight" x="545" y="247" width="233" height="20" isPrintWhenDetailOverflows="true" uuid="8c2f723b-dfe1-41e6-be85-0f59e664b60f"/>
 				<box>
 					<topPen lineWidth="0.25"/>
 				</box>
@@ -914,28 +913,28 @@
 				<text><![CDATA[Assinatura do(a) diretor(a) - nº reg. ou aut.]]></text>
 			</staticText>
 			<textField evaluationTime="Report">
-				<reportElement uuid="4b84c028-0fba-4d3c-bc46-c7af40e378f3" stretchType="RelativeToBandHeight" x="765" y="298" width="13" height="11" isPrintWhenDetailOverflows="true"/>
+				<reportElement stretchType="ContainerHeight" x="765" y="298" width="13" height="11" isPrintWhenDetailOverflows="true" uuid="4b84c028-0fba-4d3c-bc46-c7af40e378f3"/>
 				<textElement>
 					<font fontName="DejaVu Sans" size="7"/>
 				</textElement>
 				<textFieldExpression><![CDATA[" " + $V{PAGE_NUMBER}]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement uuid="efb657d7-cf1a-4682-b1b5-3f003bbf0b99" stretchType="RelativeToBandHeight" x="673" y="298" width="92" height="11" isPrintWhenDetailOverflows="true"/>
+				<reportElement stretchType="ContainerHeight" x="673" y="298" width="92" height="11" isPrintWhenDetailOverflows="true" uuid="efb657d7-cf1a-4682-b1b5-3f003bbf0b99"/>
 				<textElement textAlignment="Right" markup="html">
 					<font fontName="DejaVu Sans" size="7" isBold="false"/>
 				</textElement>
 				<textFieldExpression><![CDATA["Página: " + $V{PAGE_NUMBER} +" de "]]></textFieldExpression>
 			</textField>
 			<textField>
-				<reportElement uuid="950a7032-c508-48ea-bd9c-9adb281d700e" stretchType="RelativeToBandHeight" x="0" y="298" width="778" height="11" isPrintWhenDetailOverflows="true"/>
+				<reportElement stretchType="ContainerHeight" x="0" y="298" width="778" height="11" isPrintWhenDetailOverflows="true" uuid="950a7032-c508-48ea-bd9c-9adb281d700e"/>
 				<textElement textAlignment="Center">
 					<font fontName="DejaVu Sans" size="8"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{cidade_instituicao} +", " +$F{data_extenso} + "."]]></textFieldExpression>
 			</textField>
 			<subreport>
-				<reportElement uuid="f46efc07-72eb-4d06-ad8e-b3928061285d" x="489" y="0" width="289" height="52"/>
+				<reportElement x="489" y="0" width="289" height="52" uuid="f46efc07-72eb-4d06-ad8e-b3928061285d"/>
 				<subreportParameter name="source">
 					<subreportParameterExpression><![CDATA[$P{source}]]></subreportParameterExpression>
 				</subreportParameter>
@@ -943,7 +942,7 @@
 				<subreportExpression><![CDATA[$P{SUBREPORT_DIR} + "statistics.jasper"]]></subreportExpression>
 			</subreport>
 			<frame>
-				<reportElement uuid="39ee39f4-90fd-46c5-8bed-0c9dc77eeec7" positionType="Float" stretchType="RelativeToTallestObject" x="10" y="57" width="768" height="22" isPrintWhenDetailOverflows="true"/>
+				<reportElement positionType="Float" stretchType="ElementGroupHeight" x="10" y="57" width="768" height="22" isPrintWhenDetailOverflows="true" uuid="39ee39f4-90fd-46c5-8bed-0c9dc77eeec7"/>
 				<box>
 					<pen lineWidth="0.25"/>
 					<topPen lineWidth="0.25"/>
@@ -952,14 +951,14 @@
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textField isStretchWithOverflow="true">
-					<reportElement uuid="bf12a687-df68-458e-be47-e59a441b2c9a" positionType="Float" stretchType="RelativeToTallestObject" x="350" y="10" width="415" height="12" isPrintWhenDetailOverflows="true"/>
+					<reportElement positionType="Float" stretchType="ElementGroupHeight" x="350" y="10" width="415" height="12" isPrintWhenDetailOverflows="true" uuid="bf12a687-df68-458e-be47-e59a441b2c9a"/>
 					<textElement textAlignment="Justified">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$P{observacao}]]></textFieldExpression>
 				</textField>
 				<textField isStretchWithOverflow="true">
-					<reportElement uuid="e1959c5b-b9cc-4c92-8579-0ca194686f5d" positionType="Float" stretchType="RelativeToTallestObject" x="0" y="10" width="347" height="12" isPrintWhenDetailOverflows="true"/>
+					<reportElement positionType="Float" stretchType="ElementGroupHeight" x="0" y="10" width="347" height="12" isPrintWhenDetailOverflows="true" uuid="e1959c5b-b9cc-4c92-8579-0ca194686f5d"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 						<paragraph leftIndent="2"/>
@@ -967,7 +966,7 @@
 					<textFieldExpression><![CDATA["Rem: remanejado | Trs: transferido | Recl: reclassificado | Apr: Aprovado | ApDp: Ap. Depen. | ApCo: Aprovado pelo conselho | Rep: Reprovado | Cur: Cursando | Aba: Abandono | RpFt: Reprovado por faltas | Fal: Falecido"]]></textFieldExpression>
 				</textField>
 				<staticText>
-					<reportElement uuid="29b77150-3498-4e7c-879b-c6d1abf4e158" positionType="Float" x="0" y="0" width="100" height="10"/>
+					<reportElement positionType="Float" x="0" y="0" width="100" height="10" uuid="29b77150-3498-4e7c-879b-c6d1abf4e158"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 						<paragraph leftIndent="2"/>
@@ -975,14 +974,14 @@
 					<text><![CDATA[Legenda]]></text>
 				</staticText>
 				<staticText>
-					<reportElement uuid="a9a158cd-be88-4333-ae1f-d857bd64d926" positionType="Float" x="350" y="0" width="100" height="10"/>
+					<reportElement positionType="Float" x="350" y="0" width="100" height="10" uuid="a9a158cd-be88-4333-ae1f-d857bd64d926"/>
 					<textElement markup="none">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[Observações]]></text>
 				</staticText>
 				<line>
-					<reportElement uuid="f190c958-a271-40ab-9eff-1e13031f11b2" positionType="Float" stretchType="RelativeToBandHeight" x="347" y="0" width="1" height="22"/>
+					<reportElement positionType="Float" stretchType="ContainerHeight" x="347" y="0" width="1" height="22" uuid="f190c958-a271-40ab-9eff-1e13031f11b2"/>
 					<graphicElement>
 						<pen lineWidth="0.25"/>
 					</graphicElement>

--- a/ieducar/ReportSources/minutes-final-result.jrxml
+++ b/ieducar/ReportSources/minutes-final-result.jrxml
@@ -766,8 +766,7 @@
 						</crosstabTotalColumnHeader>
 					</columnGroup>
 					<measure name="notaMeasure" class="java.lang.String">
-						<measureExpression><![CDATA[
-								$F{nota} == null || $F{nota}.trim().isEmpty()
+						<measureExpression><![CDATA[$F{nota} == null || $F{nota}.trim().isEmpty()
 								? " - "
 								: (
 									$F{nota}.matches("[-+]?[0-9]*\\.?[0-9]+")
@@ -777,8 +776,7 @@
 										Double.valueOf($F{nota})
 									)
 									: $F{nota}
-								)
-							]]></measureExpression>
+								)]]></measureExpression>
 					</measure>
 					<measure name="count_aluno" class="java.lang.Integer">
 						<measureExpression><![CDATA[$F{aluno}]]></measureExpression>
@@ -955,7 +953,9 @@
 				<textFieldExpression><![CDATA[$F{cidade_instituicao} +", " + ($P{data_encerramento} == null || $P{data_encerramento}.isEmpty() ? $F{data_extenso} : $P{data_encerramento})]]></textFieldExpression>
 			</textField>
 			<subreport>
-				<reportElement x="489" y="0" width="289" height="52" uuid="f46efc07-72eb-4d06-ad8e-b3928061285d"/>
+				<reportElement x="386" y="0" width="389" height="52" uuid="f46efc07-72eb-4d06-ad8e-b3928061285d">
+					<property name="com.jaspersoft.studio.unit.width" value="px"/>
+				</reportElement>
 				<subreportParameter name="source">
 					<subreportParameterExpression><![CDATA[$P{source}]]></subreportParameterExpression>
 				</subreportParameter>
@@ -972,14 +972,14 @@
 					<rightPen lineWidth="0.25"/>
 				</box>
 				<textField isStretchWithOverflow="true">
-					<reportElement positionType="Float" stretchType="ElementGroupHeight" x="350" y="10" width="415" height="12" isPrintWhenDetailOverflows="true" uuid="bf12a687-df68-458e-be47-e59a441b2c9a"/>
+					<reportElement positionType="Float" stretchType="ElementGroupHeight" x="395" y="10" width="370" height="12" isPrintWhenDetailOverflows="true" uuid="bf12a687-df68-458e-be47-e59a441b2c9a"/>
 					<textElement textAlignment="Justified">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$P{observacao}]]></textFieldExpression>
 				</textField>
 				<textField isStretchWithOverflow="true">
-					<reportElement positionType="Float" stretchType="ElementGroupHeight" x="0" y="10" width="347" height="12" isPrintWhenDetailOverflows="true" uuid="e1959c5b-b9cc-4c92-8579-0ca194686f5d"/>
+					<reportElement positionType="Float" stretchType="ElementGroupHeight" x="0" y="10" width="390" height="12" isPrintWhenDetailOverflows="true" uuid="e1959c5b-b9cc-4c92-8579-0ca194686f5d"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 						<paragraph leftIndent="2"/>
@@ -995,14 +995,14 @@
 					<text><![CDATA[Legenda]]></text>
 				</staticText>
 				<staticText>
-					<reportElement positionType="Float" x="350" y="0" width="100" height="10" uuid="a9a158cd-be88-4333-ae1f-d857bd64d926"/>
+					<reportElement positionType="Float" x="397" y="0" width="100" height="10" uuid="a9a158cd-be88-4333-ae1f-d857bd64d926"/>
 					<textElement markup="none">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[Observações]]></text>
 				</staticText>
 				<line>
-					<reportElement positionType="Float" stretchType="ContainerHeight" x="347" y="0" width="1" height="22" uuid="f190c958-a271-40ab-9eff-1e13031f11b2"/>
+					<reportElement positionType="Float" stretchType="ContainerHeight" x="394" y="0" width="1" height="22" uuid="f190c958-a271-40ab-9eff-1e13031f11b2"/>
 					<graphicElement>
 						<pen lineWidth="0.25"/>
 					</graphicElement>

--- a/ieducar/ReportSources/minutes-final-result.jrxml
+++ b/ieducar/ReportSources/minutes-final-result.jrxml
@@ -753,11 +753,19 @@
 						</crosstabTotalColumnHeader>
 					</columnGroup>
 					<measure name="notaMeasure" class="java.lang.String">
-						<measureExpression><![CDATA[$F{nota} == null
-							    ? " - "
-							    : ($F{nota}.matches(".*[a-zA-Z].*")
-							        ? $F{nota}
-							        : String.format(java.util.Locale.US, "%.1f", Double.parseDouble($F{nota})))]]></measureExpression>
+						<measureExpression><![CDATA[
+								$F{nota} == null || $F{nota}.trim().isEmpty()
+								? " - "
+								: (
+									$F{nota}.matches("[-+]?[0-9]*\\.?[0-9]+")
+									? String.format(
+										java.util.Locale.US,
+										"%.1f",
+										Double.valueOf($F{nota})
+									)
+									: $F{nota}
+								)
+							]]></measureExpression>
 					</measure>
 					<measure name="count_aluno" class="java.lang.Integer">
 						<measureExpression><![CDATA[$F{aluno}]]></measureExpression>

--- a/ieducar/ReportSources/servants-signature.jrxml
+++ b/ieducar/ReportSources/servants-signature.jrxml
@@ -56,6 +56,12 @@
 	<parameter name="funcao" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[0]]></defaultValueExpression>
 	</parameter>
+	<parameter name="curso" class="java.lang.Integer">
+		<defaultValueExpression><![CDATA[0]]></defaultValueExpression>
+	</parameter>
+	<parameter name="serie" class="java.lang.String">
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
 	<parameter name="vinculo" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[0]]></defaultValueExpression>
 	</parameter>

--- a/ieducar/ReportSources/servants-signature.jrxml
+++ b/ieducar/ReportSources/servants-signature.jrxml
@@ -77,6 +77,10 @@
 	<parameter name="nao_emitir_afastados" class="java.lang.Boolean">
 		<defaultValueExpression><![CDATA[false]]></defaultValueExpression>
 	</parameter>
+	<parameter name="filtros_selecionados_b64" class="java.lang.String"/>
+	<parameter name="filtros_selecionados" class="java.lang.String">
+		<defaultValueExpression><![CDATA[($P{filtros_selecionados_b64} != null && !$P{filtros_selecionados_b64}.isEmpty()) ? new String(java.util.Base64.getDecoder().decode($P{filtros_selecionados_b64}), "UTF-8") : ""]]></defaultValueExpression>
+	</parameter>
 	<parameter name="database" class="java.lang.String"/>
 	<parameter name="source" class="java.lang.String"/>
 	<field name="nm_escola_servidor" class="java.lang.String"/>
@@ -254,7 +258,7 @@
 		<band splitType="Stretch"/>
 	</background>
 	<pageHeader>
-		<band height="102">
+		<band height="116">
 			<subreport>
 				<reportElement x="0" y="1" width="555" height="100" uuid="15562236-bb5b-4ab7-bd34-638b125489f8"/>
 				<subreportParameter name="logo">
@@ -280,6 +284,13 @@
 				</subreportParameter>
 				<subreportExpression><![CDATA[$P{SUBREPORT_DIR} + "header-portrait.jasper"]]></subreportExpression>
 			</subreport>
+			<textField isBlankWhenNull="true">
+				<reportElement x="0" y="102" width="555" height="14"/>
+				<textElement textAlignment="Center">
+					<font fontName="DejaVu Sans" size="8" isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtros_selecionados}]]></textFieldExpression>
+			</textField>
 		</band>
 	</pageHeader>
 	<columnHeader>

--- a/ieducar/ReportSources/servants.jrxml
+++ b/ieducar/ReportSources/servants.jrxml
@@ -56,6 +56,12 @@
 	<parameter name="funcao" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[0]]></defaultValueExpression>
 	</parameter>
+	<parameter name="curso" class="java.lang.Integer">
+		<defaultValueExpression><![CDATA[0]]></defaultValueExpression>
+	</parameter>
+	<parameter name="serie" class="java.lang.String">
+		<defaultValueExpression><![CDATA[""]]></defaultValueExpression>
+	</parameter>
 	<parameter name="vinculo" class="java.lang.Integer">
 		<defaultValueExpression><![CDATA[0]]></defaultValueExpression>
 	</parameter>

--- a/ieducar/ReportSources/servants.jrxml
+++ b/ieducar/ReportSources/servants.jrxml
@@ -77,6 +77,10 @@
 	<parameter name="nao_emitir_afastados" class="java.lang.Boolean">
 		<defaultValueExpression><![CDATA[false]]></defaultValueExpression>
 	</parameter>
+	<parameter name="filtros_selecionados_b64" class="java.lang.String"/>
+	<parameter name="filtros_selecionados" class="java.lang.String">
+		<defaultValueExpression><![CDATA[($P{filtros_selecionados_b64} != null && !$P{filtros_selecionados_b64}.isEmpty()) ? new String(java.util.Base64.getDecoder().decode($P{filtros_selecionados_b64}), "UTF-8") : ""]]></defaultValueExpression>
+	</parameter>	
 	<parameter name="database" class="java.lang.String"/>
 	<parameter name="source" class="java.lang.String"/>
 	<field name="nm_escola_servidor" class="java.lang.String"/>
@@ -283,7 +287,7 @@
 		<band splitType="Stretch"/>
 	</background>
 	<pageHeader>
-		<band height="102">
+		<band height="116">
 			<subreport>
 				<reportElement x="0" y="1" width="555" height="100" uuid="15562236-bb5b-4ab7-bd34-638b125489f8"/>
 				<subreportParameter name="logo">
@@ -309,6 +313,13 @@
 				</subreportParameter>
 				<subreportExpression><![CDATA[$P{SUBREPORT_DIR} + "header-portrait.jasper"]]></subreportExpression>
 			</subreport>
+			<textField isBlankWhenNull="true">
+				<reportElement x="0" y="102" width="555" height="14" />
+				<textElement textAlignment="Center">
+					<font fontName="DejaVu Sans" size="8" isBold="false"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$P{filtros_selecionados}]]></textFieldExpression>
+			</textField>
 		</band>
 	</pageHeader>
 	<columnHeader>

--- a/ieducar/ReportSources/statistics.jrxml
+++ b/ieducar/ReportSources/statistics.jrxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="portabilis_estatisticas_json" language="groovy" pageWidth="289" pageHeight="52" orientation="Landscape" columnWidth="289" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="0d2ddb19-fbc0-4ec9-9b68-1b3f41c8ef77">
+<!-- Created with Jaspersoft Studio version 7.0.2.final using JasperReports Library version 6.4.3  -->
+<jasperReport xmlns="http://jasperreports.sourceforge.net/jasperreports" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://jasperreports.sourceforge.net/jasperreports http://jasperreports.sourceforge.net/xsd/jasperreport.xsd" name="portabilis_estatisticas_json" language="groovy" pageWidth="389" pageHeight="52" orientation="Landscape" columnWidth="289" leftMargin="0" rightMargin="0" topMargin="0" bottomMargin="0" uuid="0d2ddb19-fbc0-4ec9-9b68-1b3f41c8ef77">
 	<property name="ireport.zoom" value="2.3579476910000023"/>
 	<property name="ireport.x" value="0"/>
 	<property name="ireport.y" value="0"/>
@@ -26,6 +27,7 @@
 	</queryString>
 	<field name="students" class="java.lang.String"/>
 	<field name="approved" class="java.lang.String"/>
+	<field name="approved_by_council" class="java.lang.String"/>
 	<field name="disapproved" class="java.lang.String"/>
 	<field name="studying" class="java.lang.String"/>
 	<field name="transferred" class="java.lang.String"/>
@@ -38,63 +40,63 @@
 		<band height="52" splitType="Stretch">
 			<elementGroup>
 				<textField>
-					<reportElement uuid="9196a87d-1ba1-411f-b3ad-7df32fed8489" x="67" y="2" width="20" height="12"/>
+					<reportElement x="67" y="2" width="20" height="12" uuid="9196a87d-1ba1-411f-b3ad-7df32fed8489"/>
 					<textElement textAlignment="Right">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{students}]]></textFieldExpression>
 				</textField>
 				<textField>
-					<reportElement uuid="05eb35c2-28cd-4219-a7f6-73ca742cfc6e" x="167" y="14" width="20" height="12"/>
+					<reportElement x="171" y="14" width="20" height="12" uuid="05eb35c2-28cd-4219-a7f6-73ca742cfc6e"/>
 					<textElement textAlignment="Right">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
-					<textFieldExpression><![CDATA[$F{studying}]]></textFieldExpression>
+					<textFieldExpression><![CDATA[$F{approved_by_council}]]></textFieldExpression>
 				</textField>
 				<textField>
-					<reportElement uuid="67fcfb55-035e-4136-9b06-216525242475" x="67" y="14" width="20" height="12"/>
+					<reportElement x="67" y="14" width="20" height="12" uuid="67fcfb55-035e-4136-9b06-216525242475"/>
 					<textElement textAlignment="Right">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{approved}]]></textFieldExpression>
 				</textField>
 				<textField>
-					<reportElement uuid="e6814b60-20ed-4f50-98e0-6e5bd4a8061a" x="67" y="26" width="20" height="12"/>
+					<reportElement x="67" y="26" width="20" height="12" uuid="e6814b60-20ed-4f50-98e0-6e5bd4a8061a"/>
 					<textElement textAlignment="Right">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{disapproved}]]></textFieldExpression>
 				</textField>
 				<textField>
-					<reportElement uuid="241f9b0a-a76b-4e28-b027-92cd9e8731ef" x="67" y="38" width="20" height="12"/>
+					<reportElement x="67" y="38" width="20" height="12" uuid="241f9b0a-a76b-4e28-b027-92cd9e8731ef"/>
 					<textElement textAlignment="Right">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{dependency}]]></textFieldExpression>
 				</textField>
 				<textField>
-					<reportElement uuid="8f1d630b-4cc5-4dc9-9b95-7849339dbdbb" x="167" y="26" width="20" height="12"/>
+					<reportElement x="171" y="26" width="20" height="12" uuid="8f1d630b-4cc5-4dc9-9b95-7849339dbdbb"/>
 					<textElement textAlignment="Right">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{transferred}]]></textFieldExpression>
 				</textField>
 				<textField>
-					<reportElement uuid="d0efb7ff-32b6-4f65-8f28-42cbb1f4ac7b" x="267" y="14" width="20" height="12"/>
+					<reportElement x="265" y="14" width="20" height="12" uuid="d0efb7ff-32b6-4f65-8f28-42cbb1f4ac7b"/>
 					<textElement textAlignment="Right">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{reclassified}]]></textFieldExpression>
 				</textField>
 				<textField>
-					<reportElement uuid="2cd07cef-b692-4d0d-bb4c-cb80a5aab9ea" x="267" y="26" width="20" height="12"/>
+					<reportElement x="265" y="26" width="20" height="12" uuid="2cd07cef-b692-4d0d-bb4c-cb80a5aab9ea"/>
 					<textElement textAlignment="Right">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<textFieldExpression><![CDATA[$F{abandonment}]]></textFieldExpression>
 				</textField>
 				<textField>
-					<reportElement uuid="bd35193d-367b-4dd5-a79d-7825c6f08c76" x="267" y="38" width="20" height="12"/>
+					<reportElement x="265" y="38" width="20" height="12" uuid="bd35193d-367b-4dd5-a79d-7825c6f08c76"/>
 					<textElement textAlignment="Right">
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
@@ -103,70 +105,70 @@
 			</elementGroup>
 			<elementGroup>
 				<staticText>
-					<reportElement uuid="130c027a-a6d7-4dc2-a27b-fbfc53a34a92" x="2" y="2" width="65" height="12"/>
+					<reportElement x="2" y="2" width="65" height="12" uuid="130c027a-a6d7-4dc2-a27b-fbfc53a34a92"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[Estatísticas:]]></text>
 				</staticText>
 				<staticText>
-					<reportElement uuid="fbbfa6a2-c376-4c95-b1d9-3835e0e18005" x="2" y="14" width="65" height="12"/>
+					<reportElement x="2" y="14" width="65" height="12" uuid="fbbfa6a2-c376-4c95-b1d9-3835e0e18005"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[Aprovados:]]></text>
 				</staticText>
 				<staticText>
-					<reportElement uuid="4b68b7cd-0753-4fee-ae47-8a7b44e5f652" x="2" y="26" width="65" height="12"/>
+					<reportElement x="2" y="26" width="65" height="12" uuid="4b68b7cd-0753-4fee-ae47-8a7b44e5f652"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[Reprovados:]]></text>
 				</staticText>
 				<staticText>
-					<reportElement uuid="4b68b7cd-0753-4fee-ae47-8a7b44e5f652" x="2" y="38" width="65" height="12"/>
+					<reportElement x="2" y="38" width="65" height="12" uuid="4b68b7cd-0753-4fee-ae47-8a7b44e5f652"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[Cursando dep.:]]></text>
 				</staticText>
 				<staticText>
-					<reportElement uuid="4b68b7cd-0753-4fee-ae47-8a7b44e5f652" x="102" y="14" width="65" height="12"/>
+					<reportElement x="100" y="14" width="71" height="12" uuid="4b68b7cd-0753-4fee-ae47-8a7b44e5f652"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
-					<text><![CDATA[Cursandos:]]></text>
+					<text><![CDATA[Aprov. conselho:]]></text>
 				</staticText>
 				<staticText>
-					<reportElement uuid="4b1390b6-1769-4771-a4b9-bd5a45ad7fad" x="102" y="26" width="65" height="12"/>
+					<reportElement x="100" y="26" width="71" height="12" uuid="4b1390b6-1769-4771-a4b9-bd5a45ad7fad"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[Transferidos:]]></text>
 				</staticText>
 				<staticText>
-					<reportElement uuid="89452db7-4b51-4eb5-a74d-ff5aec6bf980" x="102" y="38" width="65" height="12"/>
+					<reportElement x="100" y="38" width="71" height="12" uuid="89452db7-4b51-4eb5-a74d-ff5aec6bf980"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[Remanejados:]]></text>
 				</staticText>
 				<staticText>
-					<reportElement uuid="4b68b7cd-0753-4fee-ae47-8a7b44e5f652" x="202" y="14" width="65" height="12"/>
+					<reportElement x="200" y="14" width="65" height="12" uuid="4b68b7cd-0753-4fee-ae47-8a7b44e5f652"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[Reclassificados:]]></text>
 				</staticText>
 				<staticText>
-					<reportElement uuid="4b68b7cd-0753-4fee-ae47-8a7b44e5f652" x="202" y="26" width="65" height="12"/>
+					<reportElement x="200" y="26" width="65" height="12" uuid="4b68b7cd-0753-4fee-ae47-8a7b44e5f652"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
 					<text><![CDATA[Abandonados:]]></text>
 				</staticText>
 				<staticText>
-					<reportElement uuid="4b68b7cd-0753-4fee-ae47-8a7b44e5f652" x="202" y="38" width="65" height="12"/>
+					<reportElement x="200" y="38" width="65" height="12" uuid="4b68b7cd-0753-4fee-ae47-8a7b44e5f652"/>
 					<textElement>
 						<font fontName="DejaVu Sans" size="8"/>
 					</textElement>
@@ -174,18 +176,34 @@
 				</staticText>
 			</elementGroup>
 			<rectangle>
-				<reportElement uuid="5bcda42b-491a-4621-866a-03441c13db82" mode="Transparent" x="0" y="0" width="289" height="52"/>
+				<reportElement mode="Transparent" x="0" y="0" width="389" height="52" uuid="5bcda42b-491a-4621-866a-03441c13db82">
+					<property name="com.jaspersoft.studio.unit.width" value="pixel"/>
+				</reportElement>
 				<graphicElement>
 					<pen lineWidth="0.25"/>
 				</graphicElement>
 			</rectangle>
 			<textField>
-				<reportElement uuid="39e282c9-c431-4223-8411-1deeda9bf5fd" x="167" y="38" width="20" height="12"/>
+				<reportElement x="171" y="38" width="20" height="12" uuid="39e282c9-c431-4223-8411-1deeda9bf5fd"/>
 				<textElement textAlignment="Right">
 					<font fontName="DejaVu Sans" size="8"/>
 				</textElement>
 				<textFieldExpression><![CDATA[$F{relocated}]]></textFieldExpression>
 			</textField>
+			<textField>
+				<reportElement x="360" y="14" width="20" height="12" uuid="4a8e8227-72a9-47c7-9074-f454d0f0070a"/>
+				<textElement textAlignment="Right">
+					<font fontName="DejaVu Sans" size="8"/>
+				</textElement>
+				<textFieldExpression><![CDATA[$F{studying}]]></textFieldExpression>
+			</textField>
+			<staticText>
+				<reportElement x="295" y="14" width="65" height="12" uuid="1b331d45-813b-4170-9010-f8ef9570c6af"/>
+				<textElement>
+					<font fontName="DejaVu Sans" size="8"/>
+				</textElement>
+				<text><![CDATA[Cursandos:]]></text>
+			</staticText>
 		</band>
 	</pageHeader>
 </jasperReport>

--- a/ieducar/Reports/MinutesFinalResultReport.php
+++ b/ieducar/Reports/MinutesFinalResultReport.php
@@ -12,6 +12,15 @@ class MinutesFinalResultReport extends Portabilis_Report_ReportCore
 
     public function templateName()
     {
+        // Prioridade 2: Verificar o tipo de nota da série
+        $tipoNota = isset($this->args['tipo_nota']) ? (int) $this->args['tipo_nota'] : 1;
+        $tem_conceito_fixo = isset($this->args['tem_conceito_fixo']) ? (bool) $this->args['tem_conceito_fixo'] : false;
+                
+        // tipo_nota = 2 significa conceitual
+        if ($tipoNota == 0 || ($tipoNota == 2 && $tem_conceito_fixo)) {
+            return 'minutes-final-result-with-fixed-concept';
+        }
+
         return 'minutes-final-result';
     }
 

--- a/ieducar/Reports/MinutesFinalResultReport.php
+++ b/ieducar/Reports/MinutesFinalResultReport.php
@@ -19,6 +19,8 @@ class MinutesFinalResultReport extends Portabilis_Report_ReportCore
         // tipo_nota = 2 significa conceitual
         if ($tipoNota == 0 || ($tipoNota == 2 && $tem_conceito_fixo)) {
             return 'minutes-final-result-with-fixed-concept';
+        } elseif ($tipoNota == 2 && !$tem_conceito_fixo) {
+            return 'minutes-final-result-with-concept';
         }
 
         return 'minutes-final-result';

--- a/ieducar/Reports/RegistrationCertificateReport.php
+++ b/ieducar/Reports/RegistrationCertificateReport.php
@@ -72,8 +72,7 @@ SELECT fcn_upper(instituicao.nm_instituicao) AS nm_instituicao,
 	  (SELECT to_char(COALESCE(data_matricula,data_cadastro),'dd/mm/yyyy')
          FROM pmieducar.matricula mt
         WHERE mt.cod_matricula = matricula.cod_matricula AND
-              mt.ativo = 1 AND
-              mt.ultima_matricula = 1) as dt_matricula,
+              mt.ativo = 1) as dt_matricula,
 	   matricula.ano as matricula_ano,
        fcn_upper(instituicao.cidade) as cidade,
 
@@ -133,8 +132,7 @@ SELECT fcn_upper(instituicao.nm_instituicao) AS nm_instituicao,
 			      mt.ano = matricula.ano AND
 			      mt.ref_ref_cod_escola = matricula.ref_ref_cod_escola AND
 			      mt.ref_ref_cod_serie = matricula.ref_ref_cod_serie AND
-			      mt.ativo  = 1 AND
-			      mt.ultima_matricula = 1) AND
+			      mt.ativo  = 1) AND
        pessoa.idpes = fisica.idpes AND
        fisica.idpes = aluno.ref_idpes AND
        aluno.cod_aluno = matricula.ref_cod_aluno AND

--- a/ieducar/Reports/ServantsReport.php
+++ b/ieducar/Reports/ServantsReport.php
@@ -43,10 +43,39 @@ class ServantsReport extends Portabilis_Report_ReportCore
         $ano = $this->args['ano'] ?: 0;
         $instituicao = $this->args['instituicao'] ?: 0;
         $escola = $this->args['escola'] ?: 0;
+        $curso = $this->args['curso'] ?: 0;
+        $serie = $this->args['serie'] ?? 0;
         $funcao = $this->args['funcao'] ?: 0;
         $vinculo = $this->args['vinculo'] ?: 0;
         $periodo = $this->args['periodo'] ?: 0;
         $nao_emitir_afastados = $this->args['nao_emitir_afastados'];
+
+        $cursoSerieFilter = '';
+        if ($curso > 0 || !empty($serie)) {
+            $seriesCondition = '';
+            if (!empty($serie) && $serie !== '0') {
+                $seriesList = is_string($serie) ? preg_replace('/[^0-9,]/', '', $serie) : (string) $serie;
+                $seriesList = trim($seriesList, ',');
+                if ($seriesList !== '' && $seriesList !== '0') {
+                    $seriesCondition = "AND t.ref_ref_cod_serie IN ({$seriesList})";
+                }
+            }
+            if ($seriesCondition === '' && $curso > 0) {
+                $seriesCondition = "AND t.ref_cod_curso = {$curso}";
+            } elseif ($curso > 0) {
+                $seriesCondition .= " AND t.ref_cod_curso = {$curso}";
+            }
+            if ($seriesCondition !== '') {
+                $cursoSerieFilter = " AND EXISTS (
+                    SELECT 1 FROM modules.professor_turma pt
+                    INNER JOIN pmieducar.turma t ON t.cod_turma = pt.turma_id
+                    WHERE pt.servidor_id = servidor.cod_servidor
+                    AND pt.ano = {$ano}
+                    AND t.ref_ref_cod_escola = escola.cod_escola
+                    {$seriesCondition}
+                )";
+            }
+        }
 
         return "
 SELECT DISTINCT COALESCE(pessoa_juridica.nome, '') AS nm_escola_servidor,
@@ -110,7 +139,7 @@ SELECT DISTINCT COALESCE(pessoa_juridica.nome, '') AS nm_escola_servidor,
 				    FROM pmieducar.servidor_afastamento sa
                                        WHERE sa.ativo = 1)
              ELSE TRUE
-        END)
+        END){$cursoSerieFilter}
 group by nm_escola_servidor, pessoa.nome, escolaridade.descricao, pessoa.idpes, escola.cod_escola, fisica.cpf, fone_pessoa.fone, fone_pessoa.ddd, servidor_alocacao.ref_cod_servidor, funcao.nm_funcao
  ORDER BY nm_escola_servidor, nm_servidor_order
         ";

--- a/ieducar/Reports/StudentCardReport.php
+++ b/ieducar/Reports/StudentCardReport.php
@@ -13,12 +13,14 @@ class StudentCardReport extends Portabilis_Report_ReportCore
     public function templateName()
     {
         $modelos = [
+            0 => 'student-card-model-transport',
             1 => 'student-card-model1',
             2 => 'student-card-model2',
             3 => 'student-card-model3',
         ];
 
-        return $modelos[$this->args['modelo']];
+
+        return $this->args['instituicao'] > 1 ? $modelos[0] : $modelos[$this->args['modelo']];
     }
 
     public function requiredArgs()

--- a/ieducar/Tipos/TipoBoletim.php
+++ b/ieducar/Tipos/TipoBoletim.php
@@ -28,8 +28,8 @@ class Portabilis_Model_Report_TipoBoletim extends CoreExt_Enum
 
     public function getReports()
     {
-        $dominio = $_SERVER['HTTP_HOST'];
-        if (strpos($dominio, 'japaratinga') !== false) {
+        $anual = getenv('ANNUAL_CONCEPT') ?: 0;
+        if ($anual == 1) {
             $this->_reports[self::CONCEPTUAL] = 'conceptual-report-card-annual';
         }
 

--- a/ieducar/Views/MinutesFinalResultController.php
+++ b/ieducar/Views/MinutesFinalResultController.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\LegacyInstitution;
+use App\Models\LegacySchoolClass;
 
 class MinutesFinalResultController extends Portabilis_Controller_ReportCoreController
 {
@@ -55,12 +56,15 @@ class MinutesFinalResultController extends Portabilis_Controller_ReportCoreContr
 
     public function beforeValidation()
     {
+        $turmaId = (int) $this->getRequest()->ref_cod_turma;
+        $serieId = (int) $this->getRequest()->ref_cod_serie;
+
         $this->report->addArg('ano', (int) $this->getRequest()->ano);
         $this->report->addArg('instituicao', (int) $this->getRequest()->ref_cod_instituicao);
         $this->report->addArg('escola', (int) $this->getRequest()->ref_cod_escola);
         $this->report->addArg('curso', (int) $this->getRequest()->ref_cod_curso);
-        $this->report->addArg('serie', (int) $this->getRequest()->ref_cod_serie);
-        $this->report->addArg('turma', (int) $this->getRequest()->ref_cod_turma);
+        $this->report->addArg('serie', $serieId);
+        $this->report->addArg('turma', $turmaId);
         $this->report->addArg('situacao', (int) $this->getRequest()->situacao_matricula_id);
         $this->report->addArg('observacao', $this->getRequest()->observacao);
 
@@ -70,5 +74,32 @@ class MinutesFinalResultController extends Portabilis_Controller_ReportCoreContr
         $this->report->addArg('areas_conhecimento', trim($areasConhecimento) == '' ? 0 : $areasConhecimento);
         $this->report->addArg('filtro_areas_conhecimento', trim($areasConhecimento) == '');
         $this->report->addArg('data_encerramento', $this->getRequest()->data_encerramento);
+
+        $temConceitoFixoEnv = getenv('TEM_CONCEITO_FIXO');
+        $temConceitoFixo = ($temConceitoFixoEnv !== false && $temConceitoFixoEnv !== '') ? (bool) $temConceitoFixoEnv : false;
+        $this->report->addArg('tem_conceito_fixo', $temConceitoFixo);
+
+        $conceitoFixoEnv = getenv('CONCEITO_FIXO'); // APP ou PPC ou "" ou null
+        $conceitoFixo = ($conceitoFixoEnv !== false && $conceitoFixoEnv !== '') ? (string) $conceitoFixoEnv : '';
+        $this->report->addArg('conceito_fixo', $conceitoFixo);
+
+        // Buscar o tipo de nota da série para direcionar o relatório adequado
+        $tipoNota = 1; // Default: numérica
+        try {
+            $schoolClass = LegacySchoolClass::find($turmaId);
+            if ($schoolClass) {
+                $evaluationRule = $schoolClass->getEvaluationRule($serieId);
+                if ($evaluationRule && isset($evaluationRule->tipo_nota) && $evaluationRule->tipo_nota !== null) {
+                    // Forçar conversão para inteiro PHP puro
+                    // O Eloquent pode retornar como string, então garantimos que seja int
+                    $tipoNota = (int) $evaluationRule->tipo_nota;
+                }
+            }
+        } catch (Exception $e) {
+            // Em caso de erro, mantém o default
+        }
+        
+        // Passar como número inteiro literal (igual ao ReportConceptualCardController que passa 2 diretamente)
+        $this->report->addArg('tipo_nota', $tipoNota);
     }
 }

--- a/ieducar/Views/MinutesFinalResultController.php
+++ b/ieducar/Views/MinutesFinalResultController.php
@@ -28,15 +28,22 @@ class MinutesFinalResultController extends Portabilis_Controller_ReportCoreContr
 
         $this->inputsHelper()->textArea('observacao', ['required' => false, 'label' => 'Observações', 'placeholder' => 'Utilize este espaço para exibir uma mensagem ou recado na ata de resutado final.']);
 
-        $helperOptions = ['objectName' => 'areaconhecimento'];
-        $options = [
-            'label' => 'Áreas de conhecimento',
-            'size' => 50,
-            'required' => false,
-            'placeholder' => 'Todas',
-            'options' => ['value' => null]
-        ];
-        $this->inputsHelper()->multipleSearchAreasConhecimento('', $options, $helperOptions);
+        // $helperOptions = ['objectName' => 'areaconhecimento'];
+        // $options = [
+        //     'label' => 'Áreas de conhecimento',
+        //     'size' => 50,
+        //     'required' => false,
+        //     'placeholder' => 'Todas',
+        //     'options' => ['value' => null]
+        // ];
+        //$this->inputsHelper()->multipleSearchAreasConhecimento('', $options, $helperOptions);
+        
+        $this->inputsHelper()->date('data_encerramento', [
+            'placeholder' => '',
+            'label' => 'Data de Encerramento',
+            'value' => date('d/m/Y'),
+            'required' => false
+        ]);
 
         $this->loadResourceAssets($this->getDispatcher());
     }
@@ -62,5 +69,6 @@ class MinutesFinalResultController extends Portabilis_Controller_ReportCoreContr
 
         $this->report->addArg('areas_conhecimento', trim($areasConhecimento) == '' ? 0 : $areasConhecimento);
         $this->report->addArg('filtro_areas_conhecimento', trim($areasConhecimento) == '');
+        $this->report->addArg('data_encerramento', $this->getRequest()->data_encerramento);
     }
 }

--- a/ieducar/Views/MinutesFinalResultController.php
+++ b/ieducar/Views/MinutesFinalResultController.php
@@ -66,7 +66,9 @@ class MinutesFinalResultController extends Portabilis_Controller_ReportCoreContr
         $this->report->addArg('serie', $serieId);
         $this->report->addArg('turma', $turmaId);
         $this->report->addArg('situacao', (int) $this->getRequest()->situacao_matricula_id);
-        $this->report->addArg('observacao', $this->getRequest()->observacao);
+        
+        $observacao_encoded = base64_encode($this->getRequest()->observacao);
+        $this->report->addArg('observacao_b64', $observacao_encoded);
 
         $areasConhecimento = $this->getRequest()->areaconhecimento ?? [];
         $areasConhecimento = implode(',', array_filter($areasConhecimento));

--- a/ieducar/Views/ServantsController.php
+++ b/ieducar/Views/ServantsController.php
@@ -46,6 +46,11 @@ class ServantsController extends Portabilis_Controller_ReportCoreController
         $this->inputsHelper()->dynamic(['ano', 'instituicao', 'escola', 'vinculo']);
         $this->inputsHelper()->dynamic('escola', ['required' => false]);
         $this->inputsHelper()->dynamic('vinculo', ['required' => false]);
+        $this->inputsHelper()->dynamic('curso', ['required' => false]);
+        $this->inputsHelper()->dynamic('serie', [
+            'required' => false,
+            'options' => ['multiple' => 8, 'label' => 'Série(s)'],
+        ]);
 
         $lista_funcoes = DB::table('pmieducar.funcao')->select('cod_funcao', 'nm_funcao')->where('ativo', 1)->get()->toArray();
         $opcoes = ['' => 'Selecione'];
@@ -70,9 +75,10 @@ class ServantsController extends Portabilis_Controller_ReportCoreController
             0 => 'Padrão',
             1 => 'Para assinatura'
         ];
-        $this->campoLista('modelo', 'Modelo', $modelo, $this->modelo, null, false, '', '', false, false);
+        $this->campoRadio('modelo', 'Modelo', $modelo, $this->modelo ?? 0);
         $this->inputsHelper()->checkbox('emitir_totalizadores', ['label' => 'Adicionar totalizadores ao fim do relatório', 'value' => 1]);
-        $this->inputsHelper()->checkbox('nao_emitir_afastados', ['label' => 'Não emitir servidores afastados']);
+        $this->inputsHelper()->checkbox('nao_emitir_afastados', ['label' => 'Não emitir servidores afastados', 'value' => 1]);
+        $this->loadResourceAssets($this->getDispatcher());
     }
 
     /**
@@ -80,9 +86,18 @@ class ServantsController extends Portabilis_Controller_ReportCoreController
      */
     public function beforeValidation()
     {
+        $serieRequest = $this->getRequest()->ref_cod_serie_id
+            ?? $this->getRequest()->ref_cod_serie
+            ?? $_REQUEST['ref_cod_serie_id'] ?? null;
+        $series = is_array($serieRequest)
+            ? implode(',', array_filter(array_map('intval', $serieRequest)))
+            : (int) ($serieRequest ?? 0);
+
         $this->report->addArg('ano', (int) $this->getRequest()->ano);
         $this->report->addArg('instituicao', (int) $this->getRequest()->ref_cod_instituicao);
         $this->report->addArg('escola', (int) $this->getRequest()->ref_cod_escola);
+        $this->report->addArg('curso', (int) $this->getRequest()->ref_cod_curso);
+        $this->report->addArg('serie', $series);
         $this->report->addArg('funcao', (int) $this->getRequest()->funcao);
         $this->report->addArg('vinculo', (int) $this->getRequest()->vinculo_id);
         $this->report->addArg('periodo', (int) $this->getRequest()->periodo);

--- a/ieducar/Views/ServantsController.php
+++ b/ieducar/Views/ServantsController.php
@@ -105,6 +105,37 @@ class ServantsController extends Portabilis_Controller_ReportCoreController
         $this->report->addArg('modelo', (int) $this->getRequest()->modelo);
         $this->report->addArg('emitir_totalizadores', (bool) $this->getRequest()->emitir_totalizadores);
         $this->report->addArg('nao_emitir_afastados', (bool) $this->getRequest()->nao_emitir_afastados);
+
+        $filtros = [];
+        $curso = (int) $this->getRequest()->ref_cod_curso;
+        if ($curso) {
+            $nome = DB::table('pmieducar.curso')->where('cod_curso', $curso)->value('nm_curso');
+            $filtros[] = 'Curso: ' . ($nome ?: $curso);
+        }
+        if (!empty($series) && $series !== '0') {
+            $ids = array_filter(array_map('intval', explode(',', (string) $series)));
+            $nomes = DB::table('pmieducar.serie')->whereIn('cod_serie', $ids)->pluck('nm_serie');
+            $filtros[] = 'Série(s): ' . $nomes->implode(', ');
+        }
+        $funcao = (int) $this->getRequest()->funcao;
+        if ($funcao) {
+            $nome = DB::table('pmieducar.funcao')->where('cod_funcao', $funcao)->value('nm_funcao');
+            $filtros[] = 'Função: ' . ($nome ?: $funcao);
+        }
+        $vinculo = (int) $this->getRequest()->vinculo_id;
+        if ($vinculo) {
+            $nome = DB::table('portal.funcionario_vinculo')->where('cod_funcionario_vinculo', $vinculo)->value('nm_vinculo');
+            $filtros[] = 'Vínculo: ' . ($nome ?: $vinculo);
+        }
+        $periodo = (int) $this->getRequest()->periodo;
+        $periodos = [0 => 'Todos', 1 => 'Matutino', 2 => 'Vespertino', 3 => 'Noturno'];
+        $filtros[] = 'Período: ' . ($periodos[$periodo] ?? 'Todos');
+
+        $filtrosStr = implode(' | ', $filtros);
+        if (!mb_check_encoding($filtrosStr, 'UTF-8')) {
+            $filtrosStr = mb_convert_encoding($filtrosStr, 'UTF-8', 'ISO-8859-1');
+        }
+        $this->report->addArg('filtros_selecionados_b64', base64_encode($filtrosStr));
     }
 
     /**

--- a/ieducar/Views/ServantsController.php
+++ b/ieducar/Views/ServantsController.php
@@ -43,15 +43,16 @@ class ServantsController extends Portabilis_Controller_ReportCoreController
      */
     public function form()
     {
-        $this->inputsHelper()->dynamic(['ano', 'instituicao', 'escola', 'vinculo']);
+        $this->inputsHelper()->dynamic(['ano', 'instituicao', 'escola']);
         $this->inputsHelper()->dynamic('escola', ['required' => false]);
-        $this->inputsHelper()->dynamic('vinculo', ['required' => false]);
         $this->inputsHelper()->dynamic('curso', ['required' => false]);
         $this->inputsHelper()->dynamic('serie', [
             'required' => false,
             'options' => ['multiple' => 8, 'label' => 'Série(s)'],
         ]);
 
+        $this->inputsHelper()->dynamic('vinculo', ['required' => false]);
+        
         $lista_funcoes = DB::table('pmieducar.funcao')->select('cod_funcao', 'nm_funcao')->where('ativo', 1)->get()->toArray();
         $opcoes = ['' => 'Selecione'];
         

--- a/ieducar/Views/StudentCardController.php
+++ b/ieducar/Views/StudentCardController.php
@@ -105,6 +105,11 @@ class StudentCardController extends Portabilis_Controller_ReportCoreController
         $path = empty($configPath) ? '/var/www/ieducar/ieducar/modules/Reports/Assets/Images/StudentCard' : $configPath;
 
         $this->report->addArg('caminho_fundo_carteira_transporte', $path);
+
+
+        $assinaturaPath = env('ASSINATURA_CARTEIRA_TRANSPORTE');
+        $this->report->addArg('assinatura', $assinaturaPath ?? '');
+
         if (!isset($_POST['ref_cod_matricula'])) {
             $this->report->addArg('matricula', 0);
         } else {

--- a/ieducar/Views/StudentCardController.php
+++ b/ieducar/Views/StudentCardController.php
@@ -25,25 +25,25 @@ class StudentCardController extends Portabilis_Controller_ReportCoreController
         $this->inputsHelper()->dynamic(['ano', 'instituicao', 'escola', 'curso', 'serie', 'turma']);
         $this->inputsHelper()->dynamic('matricula', ['required' => false]);
 
-        $options = [
-            'label' => 'Situação da matrícula',
-            'resources' => [
-                1 => 'Aprovado',
-                2 => 'Reprovado',
-                14 => 'Reprovado por falta',
-                3 => 'Cursando',
-                4 => 'Transferido',
-                5 => 'Reclassificado',
-                6 => 'Abandono',
-                9 => 'Exceto Transferidos/Abandono',
-                10 => 'Todas',
-                12 => 'Aprovado com dependência',
-                16 => 'Aprovado após exame'
-            ],
-            'required' => false,
-            'value' => 9
-        ];
-        $this->inputsHelper()->select('situacao_matricula', $options);
+        // $options = [
+        //     'label' => 'Situação da matrícula',
+        //     'resources' => [
+        //         1 => 'Aprovado',
+        //         2 => 'Reprovado',
+        //         14 => 'Reprovado por falta',
+        //         3 => 'Cursando',
+        //         4 => 'Transferido',
+        //         5 => 'Reclassificado',
+        //         6 => 'Abandono',
+        //         9 => 'Exceto Transferidos/Abandono',
+        //         10 => 'Todas',
+        //         12 => 'Aprovado com dependência',
+        //         16 => 'Aprovado após exame'
+        //     ],
+        //     'required' => false,
+        //     'value' => 9
+        // ];
+        // $this->inputsHelper()->select('situacao_matricula', $options);
 
         if (config('legacy.report.mostrar_relatorios') == 'botucatu') {
             $this->inputsHelper()->hidden('modelo', ['value' => 3]);
@@ -58,15 +58,15 @@ class StudentCardController extends Portabilis_Controller_ReportCoreController
             $this->inputsHelper()->select('modelo', $options);
         }
 
-        $this->inputsHelper()->text('validade', [
-            'required' => false,
-            'label' => 'Validade',
-            'size' => 45,
-            'max_length' => 7,
-            'placeholder' => 'Informe uma data (mes/ano) (ex.: 01/2015)'
-        ]);
+        // $this->inputsHelper()->text('validade', [
+        //     'required' => false,
+        //     'label' => 'Validade',
+        //     'size' => 45,
+        //     'max_length' => 7,
+        //     'placeholder' => 'Informe uma data (mes/ano) (ex.: 01/2015)'
+        // ]);
 
-        $this->inputsHelper()->checkbox('imprimir_serie', ['label' => 'Imprimir nome da série ao lado da turma?']);
+        // $this->inputsHelper()->checkbox('imprimir_serie', ['label' => 'Imprimir nome da série ao lado da turma?']);
         $colors = [
             1 => 'Amarelo',
             2 => 'Azul',
@@ -78,7 +78,7 @@ class StudentCardController extends Portabilis_Controller_ReportCoreController
         $options = [
             'label' => 'Cor de fundo',
             'resources' => $colors,
-            'value' => 1
+            'value' => 2
         ];
         $this->inputsHelper()->select('cor_de_fundo', $options);
 
@@ -98,7 +98,7 @@ class StudentCardController extends Portabilis_Controller_ReportCoreController
         $this->report->addArg('curso', (int) $this->getRequest()->ref_cod_curso);
         $this->report->addArg('serie', (int) $this->getRequest()->ref_cod_serie);
         $this->report->addArg('turma', (int) $this->getRequest()->ref_cod_turma);
-        $this->report->addArg('validade', $this->getRequest()->validade);
+        $this->report->addArg('validade', '12/' . (int) $this->getRequest()->ano);
         $this->report->addArg('cor_de_fundo', (int) $this->getRequest()->cor_de_fundo);
 
         $configPath = config('legacy.report.caminho_fundo_carteira_transporte');
@@ -110,7 +110,7 @@ class StudentCardController extends Portabilis_Controller_ReportCoreController
         } else {
             $this->report->addArg('matricula', (int) $this->getRequest()->ref_cod_matricula);
         }
-        $this->report->addArg('situacao_matricula', $this->getRequest()->situacao_matricula);
+        $this->report->addArg('situacao_matricula', (int) 9);
 
         $this->report->addArg('modelo', (int) $this->getRequest()->modelo);
 
@@ -130,7 +130,7 @@ class StudentCardController extends Portabilis_Controller_ReportCoreController
             }
         }
         if ((int) $this->getRequest()->modelo == 1) {
-            $this->report->addArg('imprimir_serie', $this->getRequest()->imprimir_serie ? 1 : 0);
+            $this->report->addArg('imprimir_serie', 0);
         }
     }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk due to changed SQL filtering/selection logic that can alter which enrollments/records appear in reports, plus multiple JRXML template and parameter behavior changes that may affect report rendering across institutions.
> 
> **Overview**
> Updates the *final result minutes* reporting flow: adds tracking/display for `APROVADO_PELO_CONSELHO`, tightens `QueryMinutesFinalResult` to pick the latest valid `matricula_turma` and filter out placeholder-like component names, and introduces two new JRXML templates (`minutes-final-result-with-concept` / `...-with-fixed-concept`) with `MinutesFinalResultReport::templateName()` selecting by `tipo_nota` and `tem_conceito_fixo` (plus year-based rendering tweaks in `final-result-conceptual.jrxml`).
> 
> Enhances other reports: `ServantsReport` can now filter by `curso`/`serie` (EXISTS on `modules.professor_turma`) and the JRXMLs show a decoded `filtros_selecionados_b64`; `minutes-final-result.jrxml` adds `data_encerramento` and base64-decoded `observacao` plus safer numeric formatting for `nota`; `RegistrationCertificateReport` drops the `ultima_matricula` constraint; and `StudentCardReport` forces model `0` for `instituicao > 1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c674afa2f99e5c68e70f6c5d08decc354d64d73f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->